### PR TITLE
Fix reading of static layers over multiple cells.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.9
+===========
+
+- Fix bug in H-SAF static layer readers. It was not possible to read data over
+  multiple cells.
+
 Version 0.8
 ===========
 

--- a/ascat/timeseries.py
+++ b/ascat/timeseries.py
@@ -188,18 +188,12 @@ class StaticLayers(object):
         fn_format = 'porosity.nc'
         self.porosity = GriddedPointData(path, grid, fn_format=fn_format)
 
-    def close(self):
-        """
-        Close all file objects.
-        """
+    def __del__(self):
         self.topo_complex.close()
         self.wetland_frac.close()
         self.frozen_prob.close()
         self.snow_prob.close()
         self.porosity.close()
-
-    def __del__(self):
-        self.close()
 
 
 class AscatNc(GriddedNcContiguousRaggedTs):
@@ -345,15 +339,6 @@ class AscatNc(GriddedNcContiguousRaggedTs):
                              wetland_frac, porosity_gldas, porosity_hwsd)
 
         return ts
-
-    def close(self):
-        """
-        Close file-like objects.
-        """
-        if self.slayer is not None:
-            self.slayer.close()
-
-        super(AscatNc, self).close()
 
 
 class AscatSsmCdr(AscatNc):

--- a/tests/test_h_saf.py
+++ b/tests/test_h_saf.py
@@ -683,6 +683,20 @@ class Test_H111Ts(unittest.TestCase):
         np.testing.assert_approx_equal(
             result.porosity_hwsd, 0.49000001, significant=5)
 
+    def test_read_2points_cell_switch(self):
+        """
+        Test reading of two points in two different cells.
+        This did not work in the past when the static layer class
+        was closed too soon.
+        """
+
+        gpi = 3066159
+        result = self.ascat_reader.read(gpi, absolute_sm=True)
+        assert result.gpi == gpi
+        gpi = 2577735
+        result = self.ascat_reader.read(gpi, absolute_sm=True)
+        assert result.gpi == gpi
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The closing of the Static layers in the `close` method cause reading of multiple cells to fail.