### PR TITLE
Add read/write to concat-compatible xarray format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/ascat_test_data"]
 	path = tests/ascat_test_data
-	url = https://www.geo.tuwien.ac.at/downloads/gittd/ascat_test_data.git/
+	url = https://www.geo.tuwien.ac.at/gittd/ascat_test_data.git/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "tests/ascat_test_data"]
-	path = tests/ascat_test_data
-	url = https://git.geo.tuwien.ac.at/public_projects/rs/rs_testdata/ascat-test-data.git
+[submodule "tests/ascat-test-data"]
+	path = tests/ascat-test-data
+	url = https://git.geo.tuwien.ac.at/public_projects/rs/rs_testdata/ascat-test-data

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/ascat_test_data"]
 	path = tests/ascat_test_data
-	url = https://www.geo.tuwien.ac.at/gittd/ascat_test_data.git/
+	url = https://git.geo.tuwien.ac.at/public_projects/rs/rs_testdata/ascat-test-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/ascat-test-data"]
-	path = tests/ascat-test-data
-	url = https://git.geo.tuwien.ac.at/public_projects/rs/rs_testdata/ascat-test-data

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/ascat_test_data"]
+	path = tests/ascat_test_data
+	url = https://git.geo.tuwien.ac.at/public_projects/rs/rs_testdata/ascat-test-data.git

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -308,8 +308,12 @@ def var_order(dataset):
 
 
 def indexed_to_contiguous(dataset):
+    """
+    Convert an indexed dataset to a contiguous ragged array dataset.
+    Assumes that index variable is named "locationIndex".
+    """
     if isinstance(dataset, (str, Path)):
-        with xr.open_dataset(dataset) as ds:
+        with xr.open_dataset(dataset, mask_and_scale=False) as ds:
             return indexed_to_contiguous(ds)
 
     if not isinstance(dataset, xr.Dataset):
@@ -334,8 +338,12 @@ def indexed_to_contiguous(dataset):
 
 
 def contiguous_to_indexed(dataset):
+    """
+    Convert a contiguous ragged array to an indexed ragged array.
+    Assumes count variable is named "row_size".
+    """
     if isinstance(dataset, (str, Path)):
-        with xr.open_dataset(dataset) as ds:
+        with xr.open_dataset(dataset, mask_and_scale=False) as ds:
             return contiguous_to_indexed(ds)
 
     if not isinstance(dataset, xr.Dataset):
@@ -535,7 +543,7 @@ def merge_netCDFs(file_list, out_format="contiguous", dupe_window=None):
     #        return merge_netCDFs(datasets)
     # for ds in file_list:
     for ncfile in file_list:
-        with xr.open_dataset(ncfile, decode_cf=False) as ds:
+        with xr.open_dataset(ncfile, mask_and_scale=False) as ds:
             if dataset_ra_type(ds) != "indexed":
                 ds = contiguous_to_indexed(ds)
             location_id = ds["location_id"].values[
@@ -588,6 +596,7 @@ def merge_netCDFs(file_list, out_format="contiguous", dupe_window=None):
         coords="minimal",
         preprocess=preprocess,
         combine="nested",
+        mask_and_scale=False
     ) as merged_ds:
         merged_ds.load()
         merged_ds["locationIndex"] = xr.DataArray(locationIndex, dims="obs")

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -628,6 +628,7 @@ def merge_netCDFs(file_list, out_format="contiguous", dupe_window=None):
         # set dataset ID
         # TODO: should probably change this
         merged_ds.attrs["id"] = ", ".join(set([f.name for f in file_list]))
+        merged_ds.encoding["unlimited_dims"] = []
     return merged_ds
 
 

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -587,6 +587,11 @@ def merge_netCDFs(file_list, out_format="contiguous", dupe_window=None):
         for var, var_data in location_vars.items():
             dataset[var] = xr.DataArray(var_data, dims="locations")
         dataset = dataset.set_coords(["lon", "lat", "alt", "time"])
+        try:
+            # not sure how to test if time is already an index except like this
+            dataset = dataset.reset_index("time")
+        except ValueError:
+            pass
         return dataset
 
     with xr.open_mfdataset(

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -32,7 +32,6 @@ from tempfile import TemporaryDirectory
 from copy import deepcopy
 
 import numpy as np
-from numpy.testing import assert_equal
 import xarray as xr
 
 from ascat.read_native.ragged_array_ts import var_order
@@ -45,10 +44,14 @@ from ascat.read_native.ragged_array_ts import merge_netCDFs
 from ascat.read_native.ragged_array_ts import RACollection
 
 
-
 def data_setup(outdir):
     """
     Setup data for tests
+
+    Parameters
+    ----------
+    outdir : str
+        Output folder.
     """
     location_info = {
         "location_id": [1001, 1002, 1003, 1004, 1005],
@@ -66,14 +69,11 @@ def data_setup(outdir):
 
     def random_date_range(begin, d_range, n_dates):
         np.random.seed(42)
-        return sorted(
-            [
-                (np.datetime64(begin) + np.random.choice(np.arange(0, d_range))).astype(
-                    "datetime64[ns]"
-                )
-                for i in range(0, n_dates)
-            ]
-        )
+        return sorted([
+            (np.datetime64(begin) +
+             np.random.choice(np.arange(0, d_range))).astype("datetime64[ns]")
+            for i in range(0, n_dates)
+        ])
 
     # data that will be stored in contiguous ragged format
     old_data_contiguous = {
@@ -103,7 +103,8 @@ def data_setup(outdir):
         data_vars=dict(
             row_size=(["locations"], old_data_contiguous["row_size"]),
             location_id=(["locations"], old_data_contiguous["location_id"]),
-            location_description=(["locations"], old_data_contiguous["location_description"]),
+            location_description=(["locations"],
+                                  old_data_contiguous["location_description"]),
             sat_id=(["obs"], old_data_contiguous["sat_id"]),
             temp=(["obs"], old_data_contiguous["temp"]),
             humidity=(["obs"], old_data_contiguous["humidity"]),
@@ -220,8 +221,11 @@ def data_setup(outdir):
     )
 
     # data that will be stored in contiguous ragged format but with some different satellites and timestamps
-    original_time_range = random_date_range("2021-05-01 00:00:00", 31 * 24 * 3600, 9)
-    new_time_range = [i + np.timedelta64(120, "s") for i in original_time_range]
+    original_time_range = random_date_range("2021-05-01 00:00:00",
+                                            31 * 24 * 3600, 9)
+    new_time_range = [
+        i + np.timedelta64(120, "s") for i in original_time_range
+    ]
     new_data_contiguous = {
         #    "locationIndex": {1, 1, 1, 0, 0, 3, 3, 3, 3},
         "sat_id": [1, 1, 1, 1, 1, 2, 2, 2, 2],
@@ -249,7 +253,8 @@ def data_setup(outdir):
         data_vars=dict(
             row_size=(["locations"], new_data_contiguous["row_size"]),
             location_id=(["locations"], new_data_contiguous["location_id"]),
-            location_description=(["locations"], new_data_contiguous["location_description"]),
+            location_description=(["locations"],
+                                  new_data_contiguous["location_description"]),
             sat_id=(["obs"], new_data_contiguous["sat_id"]),
             temp=(["obs"], new_data_contiguous["temp"]),
             humidity=(["obs"], new_data_contiguous["humidity"]),
@@ -278,6 +283,7 @@ class TestHelpers(unittest.TestCase):
     """
     Test the helper functions
     """
+
     def assertDictNumpyEqual(self, d1, d2):
         try:
             np.testing.assert_equal(d1, d2)
@@ -373,10 +379,8 @@ class TestHelpers(unittest.TestCase):
                 "standard_name": "time",
                 "long_name": "time of measurement",
             },
-            "location_id": {
-            },
-            "location_description": {
-            },
+            "location_id": {},
+            "location_description": {},
         }
 
         for ds in [self.ctg_old, self.idx_new, self.idx_old]:
@@ -384,22 +388,29 @@ class TestHelpers(unittest.TestCase):
             with set_attributes(ds.copy()) as setted:
                 for var in setted.variables:
                     if var in expected:
-                        self.assertDictNumpyEqual(setted[var].attrs, expected[var])
+                        self.assertDictNumpyEqual(setted[var].attrs,
+                                                  expected[var])
                     else:
                         self.assertDictNumpyEqual(setted[var].attrs, {})
 
             # test that setting attrs works with extra attrs
             extra_attrs = {
-                "temp": {"foo": "bar"},
-                "time": {"spam": "eggs"},
+                "temp": {
+                    "foo": "bar"
+                },
+                "time": {
+                    "spam": "eggs"
+                },
             }
 
             with set_attributes(ds.copy(), extra_attrs) as setted:
                 for var in setted.variables:
                     if var in extra_attrs:
-                        self.assertDictNumpyEqual(setted[var].attrs, extra_attrs[var])
+                        self.assertDictNumpyEqual(setted[var].attrs,
+                                                  extra_attrs[var])
                     elif var in expected:
-                        self.assertDictNumpyEqual(setted[var].attrs, expected[var])
+                        self.assertDictNumpyEqual(setted[var].attrs,
+                                                  expected[var])
                     else:
                         self.assertDictNumpyEqual(setted[var].attrs, {})
 
@@ -488,7 +499,6 @@ class TestHelpers(unittest.TestCase):
                     print(var)
                     raise
 
-
     # @classmethod
     # def tearDownClass(cls):
     #     cls.ctg_old.close()
@@ -532,7 +542,8 @@ class TestConversion(unittest.TestCase):
         """
         converted = indexed_to_contiguous(self.idx_old)
         for var in converted.variables:
-            self.assertNanEqual(converted[var].values, self.ctg_old[var].values)
+            self.assertNanEqual(converted[var].values,
+                                self.ctg_old[var].values)
 
     def test_contiguous_to_indexed(self):
         """
@@ -540,13 +551,15 @@ class TestConversion(unittest.TestCase):
         """
         converted = contiguous_to_indexed(self.ctg_old)
         for var in converted.variables:
-            self.assertNanEqual(converted[var].values, self.idx_old[var].values)
+            self.assertNanEqual(converted[var].values,
+                                self.idx_old[var].values)
 
     # @classmethod
     # def tearDownClass(cls):
     #     cls.ctg_old.close()
     #     cls.idx_new.close()
     #     cls.idx_old.close()
+
 
 class TestMerge(unittest.TestCase):
     """
@@ -569,7 +582,8 @@ class TestMerge(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = TemporaryDirectory()
         self.tmpdir = Path(self.temporary_directory.name)
-        self.ctg_ds_old, self.idx_ds_old, self.idx_ds_new, self.ctg_ds_new = data_setup(self.tmpdir)
+        self.ctg_ds_old, self.idx_ds_old, self.idx_ds_new, self.ctg_ds_new = data_setup(
+            self.tmpdir)
         self.ctg_old_fname = self.tmpdir / "contiguous_RA_old.nc"
         self.idx_new_fname = self.tmpdir / "indexed_RA_new.nc"
         self.idx_old_fname = self.tmpdir / "indexed_RA_old.nc"
@@ -597,19 +611,39 @@ class TestMerge(unittest.TestCase):
         #     print(merged)
         merged = RACollection([self.idx_old_fname, self.idx_new_fname]).merge()
         expected = {
-            "row_size": np.array([2, 3, 4, 7, 2]),
-            "lon": np.array([-114.3, -119.59, -113.61, -106.27, -110.61]),
-            "lat": np.array([38.97, 37.75, 48.68, 32.82, 44.44]),
-            "alt": np.array([np.nan, np.nan, np.nan, np.nan, np.nan]),
-            "location_id": np.array([1001, 1002, 1003, 1004, 1005]),
-            "location_description": np.array(["Great Basin", "Yosemite", "Glacier", "White Sands", "Yellowstone"]),
-            "sat_id": np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-            "temp": np.array([31, 32, 24, 23, 23, 18, 16, 17, 17, 35, 34, 34, 35, 31, 32, 32, 19, 22]),
-            "humidity": np.array([0.0, 0.0, 0.44, 0.32, 0.21, 0.97, 0.86, 0.22, 0.31, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.21]),
+            "row_size":
+            np.array([2, 3, 4, 7, 2]),
+            "lon":
+            np.array([-114.3, -119.59, -113.61, -106.27, -110.61]),
+            "lat":
+            np.array([38.97, 37.75, 48.68, 32.82, 44.44]),
+            "alt":
+            np.array([np.nan, np.nan, np.nan, np.nan, np.nan]),
+            "location_id":
+            np.array([1001, 1002, 1003, 1004, 1005]),
+            "location_description":
+            np.array([
+                "Great Basin", "Yosemite", "Glacier", "White Sands",
+                "Yellowstone"
+            ]),
+            "sat_id":
+            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+            "temp":
+            np.array([
+                31, 32, 24, 23, 23, 18, 16, 17, 17, 35, 34, 34, 35, 31, 32, 32,
+                19, 22
+            ]),
+            "humidity":
+            np.array([
+                0.0, 0.0, 0.44, 0.32, 0.21, 0.97, 0.86, 0.22, 0.31, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.21
+            ]),
         }
         # print(np.argsort(merged["time"].values))
-        time_order = np.array([2,  3,  4,  0,  1,  9, 10, 11, 12, 13, 16, 14, 15, 17,  5,  6,  7,  8])
-        expected_times = np.concatenate((self.idx_ds_old["time"].values, self.idx_ds_new["time"].values))
+        time_order = np.array(
+            [2, 3, 4, 0, 1, 9, 10, 11, 12, 13, 16, 14, 15, 17, 5, 6, 7, 8])
+        expected_times = np.concatenate(
+            (self.idx_ds_old["time"].values, self.idx_ds_new["time"].values))
         for var in expected:
             self.assertNanEqual(merged[var].values, expected[var])
         self.assertNanEqual(merged["time"].values[time_order], expected_times)
@@ -618,18 +652,38 @@ class TestMerge(unittest.TestCase):
         # Test merging indexed with contiguous
         merged = merge_netCDFs([self.ctg_old_fname, self.idx_new_fname])
         expected = {
-            "row_size": np.array([2, 3, 4, 7, 2]),
-            "lon": np.array([-114.3, -119.59, -113.61, -106.27, -110.61]),
-            "lat": np.array([38.97, 37.75, 48.68, 32.82, 44.44]),
-            "alt": np.array([np.nan, np.nan, np.nan, np.nan, np.nan]),
-            "location_id": np.array([1001, 1002, 1003, 1004, 1005]),
-            "location_description": np.array(["Great Basin", "Yosemite", "Glacier", "White Sands", "Yellowstone"]),
-            "sat_id": np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-            "temp": np.array([31, 32, 24, 23, 23, 18, 16, 17, 17, 35, 34, 34, 35, 31, 32, 32, 19, 22]),
-            "humidity": np.array([0.0, 0.0, 0.44, 0.32, 0.21, 0.97, 0.86, 0.22, 0.31, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.21]),
+            "row_size":
+            np.array([2, 3, 4, 7, 2]),
+            "lon":
+            np.array([-114.3, -119.59, -113.61, -106.27, -110.61]),
+            "lat":
+            np.array([38.97, 37.75, 48.68, 32.82, 44.44]),
+            "alt":
+            np.array([np.nan, np.nan, np.nan, np.nan, np.nan]),
+            "location_id":
+            np.array([1001, 1002, 1003, 1004, 1005]),
+            "location_description":
+            np.array([
+                "Great Basin", "Yosemite", "Glacier", "White Sands",
+                "Yellowstone"
+            ]),
+            "sat_id":
+            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+            "temp":
+            np.array([
+                31, 32, 24, 23, 23, 18, 16, 17, 17, 35, 34, 34, 35, 31, 32, 32,
+                19, 22
+            ]),
+            "humidity":
+            np.array([
+                0.0, 0.0, 0.44, 0.32, 0.21, 0.97, 0.86, 0.22, 0.31, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.33, 0.21
+            ]),
         }
-        time_order = np.array([2, 3, 4, 0, 1, 9, 10, 11, 12, 13, 16, 14, 15, 17, 5, 6, 7, 8])
-        expected_times = np.concatenate((self.idx_ds_old["time"].values, self.idx_ds_new["time"].values))
+        time_order = np.array(
+            [2, 3, 4, 0, 1, 9, 10, 11, 12, 13, 16, 14, 15, 17, 5, 6, 7, 8])
+        expected_times = np.concatenate(
+            (self.idx_ds_old["time"].values, self.idx_ds_new["time"].values))
         for var in expected:
             self.assertNanEqual(merged[var].values, expected[var])
         self.assertNanEqual(merged["time"].values[time_order], expected_times)
@@ -641,15 +695,24 @@ class TestMerge(unittest.TestCase):
         #     print(f"\"{var}\": np.array([{', '.join(merged[var].values.astype(str))}]),")
 
         expected = {
-            "row_size": np.array([2, 3, 4]),
-            "lon": np.array([-114.3, -119.59, -106.27]),
-            "lat": np.array([38.97, 37.75, 32.82]),
-            "alt": np.array([np.nan, np.nan, np.nan]),
-            "location_id": np.array([1001, 1002, 1004]),
-            "location_description": np.array(["Great Basin", "Yosemite", "White Sands"]),
-            "sat_id": np.array([1, 1, 1, 1, 1, 1, 1, 1, 1]),
-            "temp": np.array([31, 32, 24, 23, 23, 35, 34, 34, 35]),
-            "humidity": np.array([0.0, 0.0, 0.44, 0.32, 0.21, 0.0, 0.0, 0.0, 0.0]),
+            "row_size":
+            np.array([2, 3, 4]),
+            "lon":
+            np.array([-114.3, -119.59, -106.27]),
+            "lat":
+            np.array([38.97, 37.75, 32.82]),
+            "alt":
+            np.array([np.nan, np.nan, np.nan]),
+            "location_id":
+            np.array([1001, 1002, 1004]),
+            "location_description":
+            np.array(["Great Basin", "Yosemite", "White Sands"]),
+            "sat_id":
+            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1]),
+            "temp":
+            np.array([31, 32, 24, 23, 23, 35, 34, 34, 35]),
+            "humidity":
+            np.array([0.0, 0.0, 0.44, 0.32, 0.21, 0.0, 0.0, 0.0, 0.0]),
         }
         time_order = np.array([2, 3, 4, 0, 1, 5, 6, 7, 8])
         expected_times = self.ctg_ds_old["time"].values
@@ -667,19 +730,32 @@ class TestMerge(unittest.TestCase):
 
         # print(np.argsort(merged["time"].values))
         expected = {
-            "row_size": np.array([2, 3, 8]),
-            "lon": np.array([-114.3, -119.59, -106.27]),
-            "lat": np.array([38.97, 37.75, 32.82]),
-            "alt": np.array([np.nan, np.nan, np.nan]),
-            "location_id": np.array([1001, 1002, 1004]),
-            "location_description": np.array(["Great Basin", "Yosemite", "White Sands"]),
-            "sat_id": np.array([1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2]),
-            "temp": np.array([31, 32, 24, 23, 23, 35, 35, 34, 34, 34, 34, 35, 35]),
-            "humidity": np.array([0.0, 0.0, 0.44, 0.32, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            "row_size":
+            np.array([2, 3, 8]),
+            "lon":
+            np.array([-114.3, -119.59, -106.27]),
+            "lat":
+            np.array([38.97, 37.75, 32.82]),
+            "alt":
+            np.array([np.nan, np.nan, np.nan]),
+            "location_id":
+            np.array([1001, 1002, 1004]),
+            "location_description":
+            np.array(["Great Basin", "Yosemite", "White Sands"]),
+            "sat_id":
+            np.array([1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2]),
+            "temp":
+            np.array([31, 32, 24, 23, 23, 35, 35, 34, 34, 34, 34, 35, 35]),
+            "humidity":
+            np.array([
+                0.0, 0.0, 0.44, 0.32, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0
+            ]),
         }
         time_order = np.array([2, 3, 4, 0, 1, 5, 6, 7, 8, 9, 10, 11, 12])
-        expected_times = np.sort(np.concatenate((self.ctg_ds_old["time"].values,
-                                         self.ctg_ds_new["time"].values[-4:])))
+        expected_times = np.sort(
+            np.concatenate((self.ctg_ds_old["time"].values,
+                            self.ctg_ds_new["time"].values[-4:])))
         for var in expected:
             self.assertNanEqual(merged[var].values, expected[var])
         self.assertNanEqual(merged["time"].values[time_order], expected_times)
@@ -694,23 +770,41 @@ class TestMerge(unittest.TestCase):
         #     print(f"\"{var}\": np.array([{', '.join(merged[var].values.astype(str))}]),")
 
         expected = {
-            "row_size": np.array([4, 6, 8]),
-            "lon": np.array([-114.3, -119.59, -106.27]),
-            "lat": np.array([38.97, 37.75, 32.82]),
-            "alt": np.array([np.nan, np.nan, np.nan]),
-            "location_id": np.array([1001, 1002, 1004]),
-            "location_description": np.array(["Great Basin", "Yosemite", "White Sands"]),
-            "sat_id": np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2]),
-            "temp": np.array([31, 31, 32, 32, 24, 24, 23, 23, 23, 23, 35, 35, 34, 34, 34, 34, 35, 35]),
-            "humidity": np.array([0.0, 0.0, 0.0, 0.0, 0.44, 0.44, 0.32, 0.32, 0.21, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            "row_size":
+            np.array([4, 6, 8]),
+            "lon":
+            np.array([-114.3, -119.59, -106.27]),
+            "lat":
+            np.array([38.97, 37.75, 32.82]),
+            "alt":
+            np.array([np.nan, np.nan, np.nan]),
+            "location_id":
+            np.array([1001, 1002, 1004]),
+            "location_description":
+            np.array(["Great Basin", "Yosemite", "White Sands"]),
+            "sat_id":
+            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2]),
+            "temp":
+            np.array([
+                31, 31, 32, 32, 24, 24, 23, 23, 23, 23, 35, 35, 34, 34, 34, 34,
+                35, 35
+            ]),
+            "humidity":
+            np.array([
+                0.0, 0.0, 0.0, 0.0, 0.44, 0.44, 0.32, 0.32, 0.21, 0.21, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+            ]),
         }
-        time_order = np.array([4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 10, 11, 12, 13, 14, 15, 16, 17])
-        expected_times = np.sort(np.concatenate((self.ctg_ds_old["time"].values,
-                                         self.ctg_ds_new["time"].values)))
+        time_order = np.array(
+            [4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 10, 11, 12, 13, 14, 15, 16, 17])
+        expected_times = np.sort(
+            np.concatenate((self.ctg_ds_old["time"].values,
+                            self.ctg_ds_new["time"].values)))
         for var in expected:
             self.assertNanEqual(merged[var].values, expected[var])
         self.assertNanEqual(merged["time"].values[time_order], expected_times)
         merged.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -423,13 +423,13 @@ class TestHelpers(unittest.TestCase):
             # specified when actually writing the test data to file in data_setup.
             # If they were (using set_encoding), then the dtypes would be int64.
             "row_size": {
-                "dtype": np.dtype("int32"),
+                "dtype": np.dtype("int64"),
                 "zlib": True,
                 "complevel": 4,
                 "_FillValue": None,
             },
             "locationIndex": {
-                "dtype": np.dtype("int32"),
+                "dtype": np.dtype("int64"),
                 "zlib": True,
                 "complevel": 4,
                 "_FillValue": None,
@@ -453,7 +453,7 @@ class TestHelpers(unittest.TestCase):
                 "complevel": 4,
             },
             "location_id": {
-                "dtype": np.dtype("int32"),
+                "dtype": np.dtype("int64"),
                 "zlib": True,
                 "complevel": 4,
                 "_FillValue": None,
@@ -472,13 +472,13 @@ class TestHelpers(unittest.TestCase):
                 "_FillValue": None,
             },
             "sat_id": {
-                "dtype": np.dtype("int32"),
+                "dtype": np.dtype("int64"),
                 "zlib": True,
                 "complevel": 4,
                 "_FillValue": None,
             },
             "temp": {
-                "dtype": np.dtype("int32"),
+                "dtype": np.dtype("int64"),
                 "zlib": True,
                 "complevel": 4,
                 "_FillValue": None,

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2023, TU Wien, Department of Geodesy and Geoinformation
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of TU Wien, Department of Geodesy and Geoinformation
+#      nor the names of its contributors may be used to endorse or promote
+#      products derived from this software without specific prior written
+#      permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL TU WIEN DEPARTMENT OF GEODESY AND
+# GEOINFORMATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from pathlib import Path
+from datetime import datetime
+from tempfile import TemporaryDirectory
+
+import numpy as np
+from numpy.testing import assert_equal
+import xarray as xr
+
+from ascat.read_native.ragged_array_ts import var_order
+from ascat.read_native.ragged_array_ts import indexed_to_contiguous
+from ascat.read_native.ragged_array_ts import contiguous_to_indexed
+from ascat.read_native.ragged_array_ts import dataset_ra_type
+from ascat.read_native.ragged_array_ts import set_attributes
+from ascat.read_native.ragged_array_ts import create_encoding
+from ascat.read_native.ragged_array_ts import merge_netCDFs
+
+
+def data_setup():
+    """
+    Setup data for tests
+    """
+    location_info = {
+        "location_id": [1001, 1002, 1003, 1004, 1005],
+        "lat": [38.97, 37.75, 48.68, 32.82, 44.44],
+        "lon": [-114.30, -119.59, -113.61, -106.27, -110.61],
+        "alt": [np.nan, np.nan, np.nan, np.nan, np.nan],
+        "location_description": [
+            "Great Basin",
+            "Yosemite",
+            "Glacier",
+            "White Sands",
+            "Yellowstone",
+        ],
+    }
+
+    def random_date_range(begin, d_range, n_dates):
+        return sorted(
+            [
+                (np.datetime64(begin) + np.random.choice(np.arange(0, d_range))).astype(
+                    "datetime64[ns]"
+                )
+                for i in range(0, n_dates)
+            ]
+        )
+
+    # data that will be stored in contiguous ragged format
+    data_contiguous = {
+        #    "locationIndex": {1, 1, 1, 0, 0, 3, 3, 3, 3},
+        "temp": [24, 23, 23, 31, 32, 35, 34, 34, 35],
+        "humidity": [0.44, 0.32, 0.21, 0, 0, 0, 0, 0, 0],
+        "location_id": [1002, 1001, 1004],
+        "location_description": ["Yosemite", "Great Basin", "White Sands"],
+        "time": random_date_range("2021-05-01 00:00:00", 31 * 24 * 3600, 9),
+        "row_size": [3, 2, 4],
+    }
+    data_contiguous["lon"] = [
+        location_info["lon"][location_info["location_id"].index(s)]
+        for s in data_contiguous["location_id"]
+    ]
+    data_contiguous["lat"] = [
+        location_info["lat"][location_info["location_id"].index(s)]
+        for s in data_contiguous["location_id"]
+    ]
+    data_contiguous["alt"] = [
+        location_info["alt"][location_info["location_id"].index(s)]
+        for s in data_contiguous["location_id"]
+    ]
+    # new data we want to add on top, which is in indexed ragged format
+    new_data_indexed = {
+        "locationIndex": [1, 2, 1, 1, 2, 0, 0, 0, 0],
+        "temp": [31, 19, 32, 32, 22, 18, 16, 17, 17],
+        "humidity": [0, 0.33, 0, 0, 0.21, 0.97, 0.86, 0.22, 0.31],
+        "location_id": [1003, 1004, 1005],
+        "location_description": ["Glacier", "White Sands", "Yellowstone"],
+        "time": random_date_range("2021-06-01 00:00:00", 30 * 24 * 3600, 9),
+    }
+    new_data_indexed["lon"] = [
+        location_info["lon"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+    new_data_indexed["lat"] = [
+        location_info["lat"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+    new_data_indexed["alt"] = [
+        location_info["alt"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+
+    ctg_ds = xr.Dataset(
+        data_vars=dict(
+            row_size=(["locations"], data_contiguous["row_size"]),
+            location_id=(["locations"], data_contiguous["location_id"]),
+            location_description=(["locations"], data_contiguous["location_description"]),
+            temp=(["obs"], data_contiguous["temp"]),
+            humidity=(["obs"], data_contiguous["humidity"]),
+        ),
+        coords=dict(
+            lon=(["locations"], data_contiguous["lon"]),
+            lat=(["locations"], data_contiguous["lat"]),
+            alt=(["locations"], data_contiguous["alt"]),
+            time=(["obs"], data_contiguous["time"]),
+        ),
+        attrs=dict(
+            id="test_contiguous.nc",
+            date_created=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            featureType="timeSeries",
+        ),
+    )
+
+    idx_ds = xr.Dataset(
+        data_vars=dict(
+            locationIndex=(["obs"], new_data_indexed["locationIndex"]),
+            location_id=(["locations"], new_data_indexed["location_id"]),
+            location_description=(
+                ["locations"],
+                new_data_indexed["location_description"],
+            ),
+            temp=(["obs"], new_data_indexed["temp"]),
+            humidity=(["obs"], new_data_indexed["humidity"]),
+        ),
+        coords=dict(
+            lon=(["locations"], new_data_indexed["lon"]),
+            lat=(["locations"], new_data_indexed["lat"]),
+            alt=(["locations"], new_data_indexed["alt"]),
+            time=(["obs"], new_data_indexed["time"]),
+        ),
+        attrs=dict(
+            id="test_indexed.nc",
+            date_created=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            featureType="timeSeries",
+        ),
+    )
+
+    new_data_indexed = {
+        "locationIndex": [0, 0, 0, 1, 1, 2, 2, 2, 2],
+        "temp": [24, 23, 23, 31, 32, 35, 34, 34, 35],
+        "humidity": [0.44, 0.32, 0.21, 0, 0, 0, 0, 0, 0],
+        "location_id": [1002, 1001, 1004],
+        "location_description": ["Yosemite", "Great Basin", "White Sands"],
+        "time": random_date_range("2021-05-01 00:00:00", 31 * 24 * 3600, 9),
+    }
+    new_data_indexed["lon"] = [
+        location_info["lon"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+    new_data_indexed["lat"] = [
+        location_info["lat"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+    new_data_indexed["alt"] = [
+        location_info["alt"][location_info["location_id"].index(s)]
+        for s in new_data_indexed["location_id"]
+    ]
+    idx_ds_2 = xr.Dataset(
+        data_vars=dict(
+            locationIndex=(["obs"], new_data_indexed["locationIndex"]),
+            location_id=(["locations"], new_data_indexed["location_id"]),
+            location_description=(
+                ["locations"],
+                new_data_indexed["location_description"],
+            ),
+            temp=(["obs"], new_data_indexed["temp"]),
+            humidity=(["obs"], new_data_indexed["humidity"]),
+        ),
+        coords=dict(
+            lon=(["locations"], new_data_indexed["lon"]),
+            lat=(["locations"], new_data_indexed["lat"]),
+            alt=(["locations"], new_data_indexed["alt"]),
+            time=(["obs"], new_data_indexed["time"]),
+        ),
+        attrs=dict(
+            id="test_indexed_2.nc",
+            date_created=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            featureType="timeSeries",
+        ),
+    )
+
+    ctg_ds.to_netcdf(tmpdir / "contiguous_RA.nc")
+    idx_ds.to_netcdf(tmpdir / "indexed_RA.nc")
+    idx_ds_2.to_netcdf(tmpdir / "indexed_RA_2.nc")
+
+
+class TestHelpers(unittest.TestCase):
+    """
+    Test the helper functions
+    """
+    def assertDictNumpyEqual(self, d1, d2, msg):
+        try:
+            np.testing.assert_equal(d1, d2)
+        except AssertionError as e:
+            raise self.failureException(msg) from e
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctg_old = xr.open_dataset(tmpdir / "contiguous_RA.nc")
+        cls.idx_new = xr.open_dataset(tmpdir / "indexed_RA.nc")
+        cls.idx_old = xr.open_dataset(tmpdir / "indexed_RA_2.nc")
+
+    def setUp(self):
+        self.addTypeEqualityFunc(dict, self.assertDictNumpyEqual)
+    #     self.ctg_old = xr.open_dataset(tmpdir / "contiguous_RA.nc")
+    #     self.idx_new = xr.open_dataset(tmpdir / "indexed_RA.nc")
+    #     self.idx_old = xr.open_dataset(tmpdir / "indexed_RA_2.nc")
+
+    def test_var_order(self):
+        """
+        Test var_order
+        """
+        # print(list(self.ctg_old.variables))
+        ctg_expected = [
+            "row_size",
+            "lon",
+            "lat",
+            "alt",
+            "location_id",
+            "location_description",
+            "time",
+            "temp",
+            "humidity",
+        ]
+        idx_expected = ctg_expected.copy()
+        idx_expected.remove("row_size")
+        idx_expected.insert(0, "locationIndex")
+
+        self.assertEqual(list(var_order(self.ctg_old).variables), ctg_expected)
+        self.assertEqual(list(var_order(self.idx_new).variables), idx_expected)
+        self.assertEqual(list(var_order(self.idx_old).variables), idx_expected)
+
+    def test_dataset_ra_type(self):
+        """
+        Test dataset_ra_type
+        """
+        self.assertEqual(dataset_ra_type(self.ctg_old), "contiguous")
+        self.assertEqual(dataset_ra_type(self.idx_new), "indexed")
+        self.assertEqual(dataset_ra_type(self.idx_old), "indexed")
+        neither = self.ctg_old.copy()
+        neither = neither.drop_vars(["row_size"])
+        self.assertRaises(ValueError, dataset_ra_type, neither)
+        neither.close()
+
+    def test_set_attributes(self):
+        """
+        Test set_attributes
+        """
+        expected = {
+            "row_size": {
+                "long_name": "number of observations at this location",
+                "sample_dimension": "obs",
+            },
+            "locationIndex": {
+                "long_name": "which location this observation is for",
+                "sample_dimension": "locations",
+            },
+            "lon": {
+                "standard_name": "longitude",
+                "long_name": "location longitude",
+                "units": "degrees_east",
+                "valid_range": np.array([-180, 180], dtype=float),
+            },
+            "lat": {
+                "standard_name": "latitude",
+                "long_name": "location latitude",
+                "units": "degrees_north",
+                "valid_range": np.array([-90, 90], dtype=float),
+            },
+            "alt": {
+                "standard_name": "height",
+                "long_name": "vertical distance above the surface",
+                "units": "m",
+                "positive": "up",
+                "axis": "Z",
+            },
+            "time": {
+                "standard_name": "time",
+                "long_name": "time of measurement",
+            },
+            "location_id": {
+            },
+            "location_description": {
+            },
+        }
+
+        for ds in [self.ctg_old, self.idx_new, self.idx_old]:
+            # test that setting attrs works with no extra attrs
+            with set_attributes(ds.copy()) as setted:
+                for var in setted.variables:
+                    if var in expected:
+                        self.assertEqual(setted[var].attrs, expected[var])
+                    else:
+                        self.assertEqual(setted[var].attrs, {})
+
+            # test that setting attrs works with extra attrs
+            extra_attrs = {
+                "temp": {"foo": "bar"},
+                "time": {"spam": "eggs"},
+            }
+
+            with set_attributes(ds.copy(), extra_attrs) as setted:
+                for var in setted.variables:
+                    if var in extra_attrs:
+                        self.assertEqual(setted[var].attrs, extra_attrs[var])
+                    elif var in expected:
+                        self.assertEqual(setted[var].attrs, expected[var])
+                    else:
+                        self.assertEqual(setted[var].attrs, {})
+
+    def test_create_encoding(self):
+        """
+        Test create_encoding
+        """
+        expected = {
+            "row_size": {
+                "dtype": np.dtype("int64"),
+                "zlib": True,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+            "locationIndex": {
+                "dtype": np.dtype("int64"),
+                "zlib": True,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+            "lon": {
+                "dtype": "float32",
+                "_FillValue": None,
+                "zlib": True,
+                "complevel": 4,
+            },
+            "lat": {
+                "dtype": "float32",
+                "_FillValue": None,
+                "zlib": True,
+                "complevel": 4,
+            },
+            "alt": {
+                "dtype": "float32",
+                "_FillValue": None,
+                "zlib": True,
+                "complevel": 4,
+            },
+            "location_id": {
+                "dtype": np.dtype("int64"),
+                "zlib": True,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+            "time": {
+                "dtype": "float64",
+                "units": "days since 1900-01-01 00:00:00",
+                "_FillValue": None,
+                "zlib": True,
+                "complevel": 4,
+            },
+            "location_description": {
+                "dtype": np.dtype("O"),
+                "zlib": False,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+            "temp": {
+                "dtype": np.dtype("int64"),
+                "zlib": True,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+            "humidity": {
+                "dtype": np.dtype("float64"),
+                "zlib": True,
+                "complevel": 4,
+                "_FillValue": None,
+            },
+        }
+        for ds in [self.ctg_old, self.idx_new, self.idx_old]:
+            ds_encoding = create_encoding(ds)
+            for var in ds.variables:
+                self.assertEqual(expected[var], ds_encoding[var])
+
+    # def tearDown(self):
+    #     self.ctg_old.close()
+    #     self.idx_new.close()
+    #     self.idx_old.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ctg_old.close()
+        cls.idx_new.close()
+        cls.idx_old.close()
+
+
+class TestConversion():
+    """
+    Test the conversion functions
+    """
+    def setUp(self):
+        """
+        Set up the test data
+        """
+        pass
+
+    def test_indexed_to_contiguous(self):
+        """
+        Test conversion of indexed ragged array to contiguous ragged array
+        """
+        pass
+
+    def test_contiguous_to_indexed(self):
+        """
+        Test conversion of contiguous ragged array to indexed ragged array
+        """
+        pass
+
+
+class TestMerge():
+    """
+    Test the merge function
+    """
+
+    def setUp(self):
+        return
+
+    def test_merge_netCDFs(self):
+        return
+
+
+if __name__ == "__main__":
+    with TemporaryDirectory() as temp_directory:
+        tmpdir = Path(temp_directory)
+        data_setup()
+        unittest.main(exit=False)

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -657,17 +657,38 @@ class TestMerge(unittest.TestCase):
             "temp": np.array([24, 23, 23, 31, 32, 35, 35, 34, 34, 34, 34, 35, 35]),
             "humidity": np.array([0.44, 0.32, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
         }
-        time_order = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
         expected_times = np.sort(np.concatenate((self.ctg_ds_old["time"].values,
                                          self.ctg_ds_new["time"].values[-4:])))
         for var in expected:
             self.assertNanEqual(merged[var].values, expected[var])
-        self.assertNanEqual(merged["time"].values[time_order], expected_times)
+        self.assertNanEqual(merged["time"].values, expected_times)
         merged.close()
 
         # Test merging contiguous with contiguous with different satellites
         # Passing a smaller dupe_window here will include more values from the
         # satellite in the first dataset
+        merged = merge_netCDFs([self.ctg_old_fname, self.ctg_new_fname],
+                               dupe_window=np.timedelta64(1, "m"))
+        # for var in merged.variables:
+        #     print(f"\"{var}\": np.array([{', '.join(merged[var].values.astype(str))}]),")
+
+        expected = {
+            "row_size": np.array([6, 4, 8]),
+            "lon": np.array([-119.59, -114.3, -106.27]),
+            "lat": np.array([37.75, 38.97, 32.82]),
+            "alt": np.array([np.nan, np.nan, np.nan]),
+            "location_id": np.array([1002, 1001, 1004]),
+            "location_description": np.array(["Yosemite", "Great Basin", "White Sands"]),
+            "sat_id": np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2]),
+            "temp": np.array([24, 24, 23, 23, 23, 23, 31, 31, 32, 32, 35, 35, 34, 34, 34, 34, 35, 35]),
+            "humidity": np.array([0.44, 0.44, 0.32, 0.32, 0.21, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        }
+        expected_times = np.sort(np.concatenate((self.ctg_ds_old["time"].values,
+                                         self.ctg_ds_new["time"].values)))
+        for var in expected:
+            self.assertNanEqual(merged[var].values, expected[var])
+        self.assertNanEqual(merged["time"].values, expected_times)
+        merged.close()
 
 if __name__ == "__main__":
     unittest.main(exit=False)

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -419,9 +419,6 @@ class TestHelpers(unittest.TestCase):
         Test create_encoding
         """
         expected = {
-            # we expect int32 dtypes below rather than int64 because no dtypes were
-            # specified when actually writing the test data to file in data_setup.
-            # If they were (using set_encoding), then the dtypes would be int64.
             "row_size": {
                 "dtype": np.dtype("int64"),
                 "zlib": True,

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -691,4 +691,4 @@ class TestMerge(unittest.TestCase):
         merged.close()
 
 if __name__ == "__main__":
-    unittest.main(exit=False)
+    unittest.main()


### PR DESCRIPTION
This adds methods to CRANcFile and IRANcFile to read in netcdf time series files from Indexed Ragged Array or Contiguous Ragged Array format into a compatible Indexed Ragged Array format that is easy to concatenate to other time series from the same grid cell, and a writer that writes these compatible arrays to netcdf time series in Contiguous Ragged Array format.

This is achieved by filling out the coordinates and variables in the `locations` dimension with data for all `location_id`s in the relevant cell, sorting that dimension by `location_id`, and then updating the `locationIndex` for all observations to align with the new ordering. In this way, a given `locationIndex` refers to the same `location_id` for any time series produced in a given cell, and they can be concatenated safely.

When writing to Contiguous Ragged Array format, observations are ordered by `locationIndex` and by `time`, a `row_size` variable is calculated from the `locationIndex`, `locationIndex` is dropped, and appropriate attributes and encoding are set.

Some questions that still remain:

- Should the readers live in CRANcFile and IRANcFile objects, or is there a better place, perhaps in GridCellFiles?
- Is it ok for `compatible_writer` to live by itself as a function? I didn't want to put it as an object method since it operates on the concatenation result of several objects' data. I also don't like that I have some helper functions and dictionaries just hanging out in there, I might fold those into the compatible_writer
- Still need to sort out some attributes/encoding/NaN questions