### PR TITLE
Add end_inclusive option to ChronFiles

### DIFF
--- a/src/ascat/file_handling.py
+++ b/src/ascat/file_handling.py
@@ -723,7 +723,7 @@ class ChronFiles(MultiFileHandler):
         search_date_fmt="%Y%m%d*",
         date_field="date",
         date_field_fmt="%Y%m%d",
-        end_inclusive=False,
+        end_inclusive=True,
     ):
         """
         Search files for time period.
@@ -777,7 +777,7 @@ class ChronFiles(MultiFileHandler):
         search_date_fmt="%Y%m%d*",
         date_field="date",
         date_field_fmt="%Y%m%d",
-        end_inclusive=False,
+        end_inclusive=True,
         **kwargs,
     ):
         """

--- a/src/ascat/file_handling.py
+++ b/src/ascat/file_handling.py
@@ -723,6 +723,7 @@ class ChronFiles(MultiFileHandler):
         search_date_fmt="%Y%m%d*",
         date_field="date",
         date_field_fmt="%Y%m%d",
+        end_inclusive=False,
     ):
         """
         Search files for time period.
@@ -741,6 +742,9 @@ class ChronFiles(MultiFileHandler):
             Date field name (default: "date").
         date_field_fmt : str, optional
             Date field string format (default: %Y%m%d).
+        end_inclusive : bool, optional
+            Include files from a dt_delta length period beyond dt_end if True
+            (default: False).
 
         Returns
         -------
@@ -749,8 +753,9 @@ class ChronFiles(MultiFileHandler):
         """
         filenames = []
 
-        for dt_cur in np.arange(dt_start, dt_end + dt_delta,
-                                dt_delta).astype(datetime):
+        dt_end = dt_end + dt_delta if end_inclusive else dt_end
+
+        for dt_cur in np.arange(dt_start, dt_end, dt_delta).astype(datetime):
             files, dates = self.search_date(
                 dt_cur,
                 search_date_fmt,
@@ -758,7 +763,7 @@ class ChronFiles(MultiFileHandler):
                 date_field_fmt,
                 return_date=True)
             for f, dt in zip(files, dates):
-                if f not in filenames and dt >= dt_start and dt < dt_end + dt_delta:
+                if f not in filenames and dt >= dt_start and dt < dt_end:
                     filenames.append(f)
 
         return filenames

--- a/src/ascat/file_handling.py
+++ b/src/ascat/file_handling.py
@@ -704,7 +704,8 @@ class ChronFiles(MultiFileHandler):
         fn_read_fmt[date_field] = timestamp.strftime(search_date_fmt)
 
         fs = FileSearch(self.root_path, self.ft.fn_templ, self.ft.sf_templ)
-        filenames = sorted(fs.search(fn_read_fmt, sf_read_fmt))
+        key_func = lambda x: self._parse_date(x, date_field, date_field_fmt)
+        filenames = sorted(fs.search(fn_read_fmt, sf_read_fmt), key=key_func)
 
         if return_date:
             dates = []

--- a/src/ascat/file_handling.py
+++ b/src/ascat/file_handling.py
@@ -777,6 +777,7 @@ class ChronFiles(MultiFileHandler):
         search_date_fmt="%Y%m%d*",
         date_field="date",
         date_field_fmt="%Y%m%d",
+        end_inclusive=False,
         **kwargs,
     ):
         """
@@ -807,7 +808,7 @@ class ChronFiles(MultiFileHandler):
         """
         filenames = self.search_period(dt_start - dt_buffer, dt_end, dt_delta,
                                        search_date_fmt, date_field,
-                                       date_field_fmt)
+                                       date_field_fmt, end_inclusive)
 
         data = []
 

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -465,7 +465,7 @@ class TestChronFiles(CustomTestCase):
         """
         timestamp = datetime(2022, 1, 1)
         filenames = self.chron_files.search_date(timestamp,
-                                                 date_str="%Y%m%d",
+                                                 date_field_fmt="%Y%m%d",
                                                  date_field="date")
         expected_filenames = [
             str(self.tmpdir / "temperature/EN01234/20220101_ascat.csv")
@@ -484,7 +484,6 @@ class TestChronFiles(CustomTestCase):
         expected_filenames = [
             str(self.tmpdir / "temperature/EN01234/20220101_ascat.csv"),
             str(self.tmpdir / "temperature/EN01234/20220102_ascat.csv"),
-            str(self.tmpdir / "temperature/EN01234/20220103_ascat.csv")
         ]
         self.assertTrue(filenames)
         self.assertEqual(filenames, expected_filenames)

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -484,6 +484,24 @@ class TestChronFiles(CustomTestCase):
         expected_filenames = [
             str(self.tmpdir / "temperature/EN01234/20220101_ascat.csv"),
             str(self.tmpdir / "temperature/EN01234/20220102_ascat.csv"),
+            str(self.tmpdir / "temperature/EN01234/20220103_ascat.csv")
+        ]
+        self.assertTrue(filenames)
+        self.assertEqual(filenames, expected_filenames)
+
+    def test_search_period_exclusive(self):
+        """
+        Test search period.
+        """
+        dt_start = datetime(2022, 1, 1)
+        dt_end = datetime(2022, 1, 3)
+        filenames = self.chron_files.search_period(dt_start,
+                                                   dt_end,
+                                                   dt_delta=timedelta(days=1),
+                                                   end_inclusive=False)
+        expected_filenames = [
+            str(self.tmpdir / "temperature/EN01234/20220101_ascat.csv"),
+            str(self.tmpdir / "temperature/EN01234/20220102_ascat.csv"),
         ]
         self.assertTrue(filenames)
         self.assertEqual(filenames, expected_filenames)


### PR DESCRIPTION
Currently ChronFiles.search_period includes files from the entirety of the end_dt which is passed to it, if `dt_delta` is 1 day, or from an hour of the final date if `dt_delta` is 1 hour. It's useful to be able to make this end date exclusive, so that an end date of 2021-04-03 includes files all the way through 2021-04-02, but none from 2021-04-03. The current behavior is still the default, but passing end_inclusive=False to `search_period` or `read_period` is now an option.