### PR TITLE
Filter swath fnames by location in get_filenames

### DIFF
--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -1815,7 +1815,7 @@ class SwathFileCollection:
         # now check for location_ids
         location_ids = None
         if cell is not None:
-            location_ids = self.grid.cell2gpi(cell)
+            location_ids = self.grid.grid_points_for_cell(cell)
         elif location_id is not None:
             location_ids = [location_id]
         elif coords is not None:

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -1826,9 +1826,11 @@ class SwathFileCollection:
             location_ids = self._location_id_from_geometry(geom)
 
         if location_ids is not None:
+            gpi_lookup = np.zeros(self.grid.gpis.max()+1, dtype=bool)
+            gpi_lookup[location_ids] = 1
             fnames = [f
                     for f in fnames
-                    if self._open(f) and self.fid.contains_location_ids(location_ids)]
+                    if self._open(f) and self.fid.contains_location_ids(lookup_vector=gpi_lookup)]
 
         return fnames
 

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -1570,7 +1570,7 @@ class SwathFileCollection:
 
         if date_range is not None:
             start_dt, end_dt = date_range
-            range_fnames = self._get_filenames(start_dt=start_dt, end_dt=end_dt)
+            range_fnames = self.get_filenames(start_dt=start_dt, end_dt=end_dt)
             if fnames is not None:
                 fnames = list(set(fnames).intersection(set(range_fnames)))
                 warnings.warn("Both `fnames` and `date_range` were passed. `fnames`"
@@ -1579,7 +1579,7 @@ class SwathFileCollection:
             else:
                 fnames = range_fnames
         elif fnames is None:
-            fnames = self._get_filenames()
+            fnames = self.get_filenames()
 
         self.max_buffer_memory_mb = buffer_memory_mb or self.max_buffer_memory_mb
         buffer = []
@@ -1730,7 +1730,15 @@ class SwathFileCollection:
             Geometry object; use to read data that intersects the geometry.
         """
         start_dt, end_dt = date_range
-        fnames = self._get_filenames(start_dt, end_dt)
+        fnames = self.get_filenames(
+            start_dt,
+            end_dt,
+            cell=cell,
+            location_id=location_id,
+            coords=coords,
+            bbox=bbox,
+            geom=geom,
+        )
         if cell is not None:
             data = self._read_cell(fnames, cell, **kwargs)
         elif location_id is not None:
@@ -1760,7 +1768,16 @@ class SwathFileCollection:
             self.fid.close()
             self.fid = None
 
-    def _get_filenames(self, start_dt=None, end_dt=None):
+    def get_filenames(
+            self,
+            start_dt=None,
+            end_dt=None,
+            cell=None,
+            location_id=None,
+            coords=None,
+            bbox=None,
+            geom=None,
+    ):
         """Get filenames for the given time range.
 
         Parameters
@@ -1793,6 +1810,25 @@ class SwathFileCollection:
             raise NotImplementedError("File search not implemented for this product."
                                       " Check if fn_pattern and sf_pattern are defined"
                                       f" in ioclass {self.ioclass.__name__}")
+
+
+        # now check for location_ids
+        location_ids = None
+        if cell is not None:
+            location_ids = self.grid.cell2gpi(cell)
+        elif location_id is not None:
+            location_ids = [location_id]
+        elif coords is not None:
+            location_ids = self._location_id_from_coords(*coords)
+        elif bbox is not None:
+            location_ids = self._location_id_from_bbox(bbox)
+        elif geom is not None:
+            location_ids = self._location_id_from_geometry(geom)
+
+        if location_ids is not None:
+            fnames = [f
+                    for f in fnames
+                    if self._open(f) and self.fid.contains_location_ids(location_ids)]
 
         return fnames
 
@@ -1924,6 +1960,40 @@ class SwathFileCollection:
             for arguments in tqdm(args):
                 self._write_cell_ds(*arguments)
 
+    def _location_id_from_coords(self, lat, lon):
+        """Get the location_id for a given lat/lon pair."""
+        return self.grid.find_nearest_gpi(lon, lat)[0]
+
+    def _location_id_from_bbox(self, bbox):
+        """Get the location_ids for a given bounding box.
+        (latmin, latmax, lonmin, lonmax)"""
+        return self.grid.get_bbox_grid_points(*bbox)
+
+
+    def _location_id_from_geometry(self, geom):
+        """Get the location_ids for a given geometry."""
+        bbox = geom.bounds
+        latmin, latmax, lonmin, lonmax = bbox[1], bbox[3], bbox[0], bbox[2]
+        bbox_gpis, bbox_lats, bbox_lons = self.grid.get_bbox_grid_points(
+            latmin,
+            latmax,
+            lonmin,
+            lonmax,
+            both=True
+        )
+        # now that we have the grid points that are within the bounding box, we can
+        # check which ones are actually within the geometry
+        if len(bbox_gpis) > 0:
+            geom_location_ids = [
+                gpi
+                for gpi, lat, lon in zip(bbox_gpis, bbox_lats, bbox_lons)
+                if geom.contains(Point(lon, lat))
+            ]
+        else:
+            geom_location_ids = []
+
+        return geom_location_ids
+
     def _read_cell(self, fnames, cell, **kwargs):
         """Read data from the entire cell."""
         # if there are kwargs, use them instead of self.ioclass_kws
@@ -1949,7 +2019,7 @@ class SwathFileCollection:
         data : dict of values
             data record.
         """
-        location_id, _ = self.grid.find_nearest_gpi(lon, lat)
+        location_id = self._location_id_from_coords(lat, lon)
 
         return self._read_location_id(fnames, location_id, **kwargs)
 
@@ -1961,7 +2031,7 @@ class SwathFileCollection:
         bbox : tuple or list
             Bounding box coordinates (latmin, latmax, lonmin, lonmax).
         """
-        location_ids = self.grid.get_bbox_grid_points(*bbox)
+        location_ids = self._location_id_from_bbox(bbox)
         return self._read_location_id(fnames, location_ids, **kwargs)
 
     def _read_geometry(self, fnames, geom, **kwargs):
@@ -1974,30 +2044,8 @@ class SwathFileCollection:
         geometry : shapely.geometry
             Geometry object.
         """
-        # first get the bounding box of the geometry so we can narrow down the
-        # grid points we need to check
-        bbox = geom.bounds
-        latmin, latmax, lonmin, lonmax = bbox[1], bbox[3], bbox[0], bbox[2]
-        bbox_gpis, bbox_lats, bbox_lons = self.grid.get_bbox_grid_points(
-            latmin,
-            latmax,
-            lonmin,
-            lonmax,
-            both=True
-        )
-
-        # now that we have the grid points that are within the bounding box, we can
-        # check which ones are actually within the geometry
-        if len(bbox_gpis) > 0:
-            geom_location_ids = [
-                gpi
-                for gpi, lat, lon in zip(bbox_gpis, bbox_lats, bbox_lons)
-                if geom.contains(Point(lon, lat))
-            ]
-        else:
-            geom_location_ids = []
-
-        return self._read_location_id(fnames, geom_location_ids, **kwargs)
+        location_ids = self._location_id_from_geometry(geom)
+        return self._read_location_id(fnames, location_ids, **kwargs)
 
     def _read_location_id(self, fnames, location_id, **kwargs):
         """Read data for given grid point.

--- a/src/ascat/read_native/xarray_io.py
+++ b/src/ascat/read_native/xarray_io.py
@@ -1049,6 +1049,28 @@ class SwathIOBase(ABC):
                 dropped_keys |= {key for key in attrs if key not in result}
             return result
 
+    def contains_location_ids(self, location_ids):
+        """
+        Check if the dataset contains any of the given location_ids.
+
+        Parameters
+        ----------
+        location_ids : list of int
+            Location ids to check.
+
+        Returns
+        -------
+        bool
+            True if the dataset contains any of the given location_ids, False otherwise.
+        """
+        return np.any(
+            np.isin(
+                np.unique(self._ds.location_id.values),
+                location_ids,
+                assume_unique=True
+            )
+        )
+
     def __enter__(self):
         """
         Context manager initialization.

--- a/src/ascat/read_native/xarray_io.py
+++ b/src/ascat/read_native/xarray_io.py
@@ -1225,7 +1225,10 @@ class AscatSIG0Cell12500m(AscatNetCDFCellBase):
 
 class AscatH129Swath(SwathIOBase):
     fn_pattern = "W_IT-HSAF-ROME,SAT,SSM-ASCAT-METOP{sat}-6.25-H129_C_LIIB_{date}_{placeholder}_{placeholder1}____.nc"
-    sf_pattern = {"year_folder": "{year}"}
+    sf_pattern = {
+        "satellite_folder": "metop_[abc]",
+        "year_folder": "{year}"
+    }
     date_format = "%Y%m%d%H%M%S"
     grid = grid_cache.fetch_or_store("Fib6.25", FibGrid, 6.25)["grid"]
     grid_cell_size = 5
@@ -1271,14 +1274,20 @@ class AscatH129Swath(SwathIOBase):
 
     @staticmethod
     def sf_read_fmt(timestamp):
-        return {"year_folder": {"year": f"{timestamp.year}"}}
+        return {
+            "satellite_folder": {"satellite": "metop_[abc]"},
+            "year_folder": {"year": f"{timestamp.year}"},
+        }
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename, "netcdf4", **kwargs)
 
 class AscatH129v1Swath(SwathIOBase):
     fn_pattern = "W_IT-HSAF-ROME,SAT,SSM-ASCAT-METOP{sat}-6.25km-H129_C_LIIB_{placeholder}_{placeholder1}_{date}____.nc"
-    sf_pattern = {"year_folder": "{year}"}
+    sf_pattern = {
+        "satellite_folder": "metop_[abc]",
+        "year_folder": "{year}"
+    }
     date_format = "%Y%m%d%H%M%S"
     grid = grid_cache.fetch_or_store("Fib6.25", FibGrid, 6.25)["grid"]
     grid_cell_size = 5
@@ -1314,7 +1323,10 @@ class AscatH129v1Swath(SwathIOBase):
 
     @staticmethod
     def sf_read_fmt(timestamp):
-        return {"year_folder": {"year": f"{timestamp.year}"}}
+        return {
+            "satellite_folder": {"satellite": "metop_[abc]"},
+            "year_folder": {"year": f"{timestamp.year}"},
+        }
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename, "netcdf4", **kwargs)
@@ -1370,7 +1382,10 @@ class AscatH121v1Swath(SwathIOBase):
 
 class AscatH122Swath(SwathIOBase):
     fn_pattern = "ascat_ssm_nrt_6.25km_{placeholder}Z_{date}Z_metop-{sat}_h122.nc"
-    sf_pattern = {"year_folder": "{year}"}
+    sf_pattern = {
+        "satellite_folder": "metop_[abc]",
+        "year_folder": "{year}"
+    }
     date_format = "%Y%m%d%H%M%S"
     grid = grid_cache.fetch_or_store("Fib6.25", FibGrid, 6.25)["grid"]
     grid_cell_size = 5
@@ -1410,7 +1425,10 @@ class AscatH122Swath(SwathIOBase):
 
     @staticmethod
     def sf_read_fmt(timestamp):
-        return {"year_folder": {"year": f"{timestamp.year}"}}
+        return {
+            "satellite_folder": {"satellite": "metop_[abc]"},
+            "year_folder": {"year": f"{timestamp.year}"},
+        }
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename, "netcdf4", **kwargs)
@@ -1420,7 +1438,10 @@ class AscatSIG0Swath6250m(SwathIOBase):
     Class for reading ASCAT sigma0 swath data and writing it to cells.
     """
     fn_pattern = "W_IT-HSAF-ROME,SAT,SIG0-ASCAT-METOP{sat}-6.25_C_LIIB_{placeholder}_{placeholder1}_{date}____.nc"
-    sf_pattern = {"year_folder": "{year}"}
+    sf_pattern = {
+        "satellite_folder": "metop_[abc]",
+        "year_folder": "{year}"
+    }
     date_format = "%Y%m%d%H%M%S"
     grid = grid_cache.fetch_or_store("Fib6.25", FibGrid, 6.25)["grid"]
     grid_cell_size = 5
@@ -1504,7 +1525,10 @@ class AscatSIG0Swath6250m(SwathIOBase):
 
     @staticmethod
     def sf_read_fmt(timestamp):
-        return {"year_folder": {"year": f"{timestamp.year}"}}
+        return {
+            "satellite_folder": {"satellite": "metop_[abc]"},
+            "year_folder": {"year": f"{timestamp.year}"},
+        }
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename, "netcdf4", **kwargs)
@@ -1514,7 +1538,10 @@ class AscatSIG0Swath12500m(SwathIOBase):
     Class for reading and writing ASCAT sigma0 swath data.
     """
     fn_pattern = "W_IT-HSAF-ROME,SAT,SIG0-ASCAT-METOP{sat}-12.5_C_LIIB_{placeholder}_{placeholder1}_{date}____.nc"
-    sf_pattern = {"year_folder": "{year}"}
+    sf_pattern = {
+        "satellite_folder": "metop_[abc]",
+        "year_folder": "{year}"
+    }
     date_format = "%Y%m%d%H%M%S"
     grid = grid_cache.fetch_or_store("Fib12.5", FibGrid, 12.5)["grid"]
     grid_cell_size = 5
@@ -1598,7 +1625,10 @@ class AscatSIG0Swath12500m(SwathIOBase):
 
     @staticmethod
     def sf_read_fmt(timestamp):
-        return {"year_folder": {"year": f"{timestamp.year}"}}
+        return {
+            "satellite_folder": {"satellite": "metop_[abc]"},
+            "year_folder": {"year": f"{timestamp.year}"},
+        }
 
     def __init__(self, filename,  **kwargs):
         super().__init__(filename, "netcdf4", **kwargs)

--- a/src/ascat/read_native/xarray_io.py
+++ b/src/ascat/read_native/xarray_io.py
@@ -1049,7 +1049,7 @@ class SwathIOBase(ABC):
                 dropped_keys |= {key for key in attrs if key not in result}
             return result
 
-    def contains_location_ids(self, location_ids):
+    def contains_location_ids(self, location_ids=None, lookup_vector=None):
         """
         Check if the dataset contains any of the given location_ids.
 
@@ -1063,13 +1063,19 @@ class SwathIOBase(ABC):
         bool
             True if the dataset contains any of the given location_ids, False otherwise.
         """
-        return np.any(
-            np.isin(
-                np.unique(self._ds.location_id.values),
-                location_ids,
-                assume_unique=True
+        if lookup_vector is not None:
+            return lookup_vector[self._ds.location_id.values].any()
+
+        if location_ids is not None:
+            return np.any(
+                np.in1d(
+                    np.unique(self._ds.location_id.values),
+                    location_ids,
+                    assume_unique=True
+                )
             )
-        )
+        else:
+            raise ValueError("Must provide either location_ids or lookup_vector")
 
     def __enter__(self):
         """

--- a/tests/test_ragged_array.py
+++ b/tests/test_ragged_array.py
@@ -296,7 +296,7 @@ class TestSwathFileCollection(unittest.TestCase):
                                 )
         start = datetime(2021, 1, 1)
         end = datetime(2021, 1, 2)
-        fname = a._get_filenames(start, end)
+        fname = a.get_filenames(start, end)
         outdir = Path("/home/charriso/test_cells/data-write/RADAR/hsaf/tester/metop_a")
         from time import time
 
@@ -341,7 +341,7 @@ class TestSwathFileCollection(unittest.TestCase):
                                 product_id="sig0_12.5",
                                 )
         self.assertEqual(incorrect.ioclass, AscatSIG0Swath12500m)
-        self.assertEqual(incorrect._get_filenames(datetime(2021, 1, 12), datetime(2021, 1, 13)), [])
+        self.assertEqual(incorrect.get_filenames(datetime(2021, 1, 12), datetime(2021, 1, 13)), [])
 
         # trying to read this data first raises a RuntimeWarning, since it can't find any files
         # for the requested names, then an AttributeError since it tries to read a None object.
@@ -370,10 +370,10 @@ class TestSwathFileCollection(unittest.TestCase):
                                 )
         start_p1 = datetime(2021, 1, 1)
         end_p1 = datetime(2021, 1, 4)
-        fnames_p1 = swaths._get_filenames(start_p1, end_p1)
+        fnames_p1 = swaths.get_filenames(start_p1, end_p1)
         start_p2 = datetime(2021, 1, 4)
         end_p2 = datetime(2021, 1, 7)
-        fnames_p2 = swaths._get_filenames(start_p2, end_p2)
+        fnames_p2 = swaths.get_filenames(start_p2, end_p2)
         tester = Path("/home/charriso/test_cells/data-write/RADAR/hsaf/tester/")
         outdir = tester/"cells"
         outdir_p1 = outdir / "p1"


### PR DESCRIPTION
Also makes SwathFileCollection.get_filenames() a public method rather than private, so the collection can be used to get just filenames without reading any more data than is necessary to filter them. This also gets used when reading data for a date range and saves some time, especially for longer time ranges on small study areas.

```python
import ascat.read_native.ragged_array_ts as rat
swath_source = "/path/to/swaths"
swath_collection = rat.SwathFileCollection.from_product_id(swath_source, "H121_v1.0")

bounds = (45, 50, 10, 20)
dates = (datetime(2020, 12, 1), datetime(2020, 12, 31))
bbox_fnames = swath_collection.get_filenames(dates[0], dates[1], bbox=bounds)

cells = [0, 9, 13]
cell_fnames = swath_collection.get_filenames(cell=cells)

gpis = [0, 1, 2]
gpi_fnames = swath_collection.get_filenames(location_id=gpis)

coords = (47, 15) #(lat, lon)
coord_fnames = swath_collection.get_filenames(coords=coords)

circle = Point(*coords).buffer(3)
geom_fnames = swath_collection.get_filenames(geom=circle)
```

