### PR TITLE
Fix no-date case in get_filenames()

### DIFF
--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -1798,7 +1798,7 @@ class SwathFileCollection:
             If the ioclass does not have a file search method named `chron_files`.
         """
         if start_dt is None and end_dt is None:
-            return list(self.path.glob("**/*.nc"))
+            fnames = list(self.path.glob("**/*.nc"))
         if self.chron_files:
             fnames = self.chron_files.search_period(
                 start_dt,

--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -1799,7 +1799,7 @@ class SwathFileCollection:
         """
         if start_dt is None and end_dt is None:
             fnames = list(self.path.glob("**/*.nc"))
-        if self.chron_files:
+        elif self.chron_files:
             fnames = self.chron_files.search_period(
                 start_dt,
                 end_dt,


### PR DESCRIPTION
Need to not return after getting fnames from the glob, in case there are locations to filter by