### PR TITLE
Aggregator regrid option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ console_scripts =
     hsaf_download = ascat.download.interface:run_hsaf_download
     eumetsat_download = ascat.download.interface:run_eumetsat_download
     temporal_swath_agg = ascat.aggregate.interface:run_temporal_swath_agg
+    swath_regrid = ascat.regrid.interface:run_swath_regrid
 
 [tool:pytest]
 # Specify command line options as you would do when invoking pytest directly.

--- a/src/ascat/aggregate/aggregators.py
+++ b/src/ascat/aggregate/aggregators.py
@@ -82,6 +82,20 @@ class TemporalSwathAggregator:
         self.start_dt = datetime.datetime.strptime(start_dt, "%Y-%m-%dT%H:%M:%S")
         self.end_dt = datetime.datetime.strptime(end_dt, "%Y-%m-%dT%H:%M:%S")
         self.timedelta = pd.Timedelta(t_delta)
+        if agg in [
+                "mean",
+                "median",
+                "mode",
+                "std",
+                "min",
+                "max",
+                "argmin",
+                "argmax",
+                "quantile",
+                "first",
+                "last",
+        ]:
+            agg = "nan" + agg
         self.agg = agg
 
         # assumes ONLY swath files are in the folder

--- a/src/ascat/aggregate/aggregators.py
+++ b/src/ascat/aggregate/aggregators.py
@@ -158,9 +158,6 @@ class TemporalSwathAggregator:
                 .astype(datetime.datetime)
                 .strftime("%Y%m%d%H%M%S")
             )
-            # if location_id is not an integer, convert it to an integer
-            if not np.issubdtype(ds.location_id.dtype, np.integer):
-                ds["location_id"] = ds.location_id.astype(int)
             ds = self._set_metadata(ds)
             out_name = (
                 f"ascat"
@@ -241,7 +238,7 @@ class TemporalSwathAggregator:
             },
             coords={
                 "time_chunks": time_groups,
-                "location_id": loc_groups,
+                "location_id": loc_groups.astype(int),
             },
         )
 

--- a/src/ascat/aggregate/aggregators.py
+++ b/src/ascat/aggregate/aggregators.py
@@ -357,7 +357,8 @@ class TemporalSwathAggregator:
             grouped_ds = xr.open_dataset(temp_path)
 
         groups = []
-        for timechunk, group in grouped_ds.groupby("time_chunks"):
+        for timechunk, group in grouped_ds.groupby("time_chunks", squeeze=False):
+            group = group.squeeze("time_chunks")
             if progress_to_stdout:
                 print(
                     f"writing time chunk {timechunk + 1}/{len(grouped_ds['time_chunks'])}...      ",

--- a/src/ascat/aggregate/interface.py
+++ b/src/ascat/aggregate/interface.py
@@ -32,6 +32,7 @@ import ascat.aggregate.aggregators as aggs
 
 aggs.progress_to_stdout = True
 
+
 def parse_args_temporal_swath_agg(args):
     parser = argparse.ArgumentParser(
         description='Calculate aggregates of ASCAT swath data over a given time period'
@@ -78,8 +79,14 @@ def parse_args_temporal_swath_agg(args):
         metavar='REGRID_DEG',
         help='Regrid the data to a regular grid with the given spacing in degrees'
     )
+    parser.add_argument(
+        '--grid_store',
+        metavar='GRID_STORE',
+        help='Path to a directory for storing grids and lookup tables between them'
+    )
 
-    return parser.parse_args(args), parser
+    return parser.parse_args(args)
+
 
 def temporal_swath_agg_main(cli_args):
     """
@@ -90,7 +97,7 @@ def temporal_swath_agg_main(cli_args):
     cli_args : list
         Command line arguments.
     """
-    args, parser = parse_args_temporal_swath_agg(cli_args)
+    args = parse_args_temporal_swath_agg(cli_args)
     int_args = ["snow_cover_mask", "frozen_soil_mask", "subsurface_scattering_mask"]
     for arg in int_args:
         if getattr(args, arg) is not None:
@@ -110,10 +117,12 @@ def temporal_swath_agg_main(cli_args):
         args.snow_cover_mask,
         args.frozen_soil_mask,
         args.subsurface_scattering_mask,
-        args.regrid
+        args.regrid,
+        args.grid_store
     )
 
     transf.write_time_chunks(args.outpath)
+
 
 def run_temporal_swath_agg():
     """

--- a/src/ascat/aggregate/interface.py
+++ b/src/ascat/aggregate/interface.py
@@ -121,7 +121,7 @@ def temporal_swath_agg_main(cli_args):
         args.grid_store
     )
 
-    transf.write_time_chunks(args.outpath)
+    transf.write_time_steps(args.outpath)
 
 
 def run_temporal_swath_agg():

--- a/src/ascat/aggregate/interface.py
+++ b/src/ascat/aggregate/interface.py
@@ -73,6 +73,11 @@ def parse_args_temporal_swath_agg(args):
         metavar='SUBSCAT_MASK',
         help='Subsurface scattering probability value above which to mask the source data'
     )
+    parser.add_argument(
+        '--regrid',
+        metavar='REGRID_DEG',
+        help='Regrid the data to a regular grid with the given spacing in degrees'
+    )
 
     return parser.parse_args(args), parser
 
@@ -91,6 +96,11 @@ def temporal_swath_agg_main(cli_args):
         if getattr(args, arg) is not None:
             setattr(args, arg, int(getattr(args, arg)))
 
+    float_args = ["regrid"]
+    for arg in float_args:
+        if getattr(args, arg) is not None:
+            setattr(args, arg, float(getattr(args, arg)))
+
     transf = aggs.TemporalSwathAggregator(
         args.filepath,
         args.start_dt,
@@ -99,7 +109,8 @@ def temporal_swath_agg_main(cli_args):
         args.agg,
         args.snow_cover_mask,
         args.frozen_soil_mask,
-        args.subsurface_scattering_mask
+        args.subsurface_scattering_mask,
+        args.regrid
     )
 
     transf.write_time_chunks(args.outpath)

--- a/src/ascat/read_native/xarray_io.py
+++ b/src/ascat/read_native/xarray_io.py
@@ -1337,8 +1337,8 @@ class AscatH129v1Swath(SwathIOBase):
 class AscatH121v1Swath(SwathIOBase):
     fn_pattern = "W_IT-HSAF-ROME,SAT,SSM-ASCAT-METOP{sat}-12.5km-H121_C_LIIB_{placeholder}_{placeholder1}_{date}____.nc"
     sf_pattern = {
-        "satellite_folder": "metop_[abc]",
-        "year_folder": "{year}"
+        # "satellite_folder": "metop_[abc]",
+        # "year_folder": "{year}"
     }
     date_format = "%Y%m%d%H%M%S"
     grid_sampling_km = 12.5
@@ -1377,8 +1377,8 @@ class AscatH121v1Swath(SwathIOBase):
     @staticmethod
     def sf_read_fmt(timestamp):
         return {
-            "satellite_folder": {"satellite": "metop_[abc]"},
-            "year_folder": {"year": f"{timestamp.year}"},
+            # "satellite_folder": {"satellite": "metop_[abc]"},
+            # "year_folder": {"year": f"{timestamp.year}"},
         }
 
     def __init__(self, filename, **kwargs):

--- a/src/ascat/regrid.py
+++ b/src/ascat/regrid.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024, TU Wien, Department of Geodesy and Geoinformation
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of TU Wien, Department of Geodesy and Geoinformation
+#      nor the names of its contributors may be used to endorse or promote
+#      products derived from this software without specific prior written
+#      permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL TU WIEN DEPARTMENT OF GEODESY AND
+# GEOINFORMATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from fibgrid.realization import FibGrid
+from pygeogrids.grids import genreg_grid
+
+def fib_to_standard(fibgrid, outgrid_size):
+    """
+    Convert a Fibonacci grid to a standard grid.
+
+    Parameters
+    ----------
+    lon_arr : numpy.ndarray
+        1D array of longitudes in degrees.
+    lat_arr : numpy.ndarray
+        1D array of latitudes in degrees.
+    fibgrid : fibgrid.realization.FibGrid
+        Instance of FibGrid from which lon_arr and lat_arr were generated.
+    outgrid_size : int
+        Size of the output grid in degrees.
+
+    Returns
+    -------
+    numpy.ndarray
+        1D array of values on the standard grid.
+    """
+    reg_grid = genreg_grid(outgrid_size, outgrid_size)
+    fib_to_reg_lut = fibgrid.calc_lut(reg_grid)
+    # new_data_gpis = fib_to_reg_lut[fib_gpis]
+    # out_lons, out_lats = reg_grid.gpi2lonlat(out_gpis)
+    return reg_grid
+
+def fib_to_standard_ds(ds, fibgrid, outgrid_size):
+    """
+    Convert a dataset from a Fibonacci grid to a standard grid.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset with lon and lat dimensions.
+    fibgrid : fibgrid.realization.FibGrid
+        Instance of FibGrid from which lon_arr and lat_arr were generated.
+    outgrid_size : int
+        Size of the output grid in degrees.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset with lon and lat dimensions.
+    """
+
+    new_grid = fib_to_standard(
+        fibgrid,
+        outgrid_size,
+    )
+    new_gpis = new_grid.gpis
+    new_lons = new_grid.arrlon
+    new_lats = new_grid.arrlat
+    fibgrid_lut = new_grid.calc_lut(fibgrid)
+    nearest_old_gpis = fibgrid_lut[new_gpis]
+    ds = ds.reindex(location_id=nearest_old_gpis)
+
+    # put the new gpi/lon/lat data onto the grouped_ds as well
+    ds["location_id"] = ("location_id", new_gpis)
+    ds["lon"] = ("location_id", new_lons)
+    ds["lat"] = ("location_id", new_lats)
+
+    # finally we turn lat and lon into their own dimensions by making a multiindex
+    # out of them and then unstacking it.
+    ds = ds.set_index(location_id=["lat", "lon"])
+    ds = ds.unstack()
+
+    return ds

--- a/src/ascat/regrid/interface.py
+++ b/src/ascat/regrid/interface.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024, TU Wien, Department of Geodesy and Geoinformation
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of TU Wien, Department of Geodesy and Geoinformation
+#      nor the names of its contributors may be used to endorse or promote
+#      products derived from this software without specific prior written
+#      permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL TU WIEN DEPARTMENT OF GEODESY AND
+# GEOINFORMATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import argparse
+from pathlib import Path
+
+import xarray as xr
+
+from ascat.read_native.xarray_io import get_swath_product_id
+from ascat.read_native.xarray_io import swath_io_catalog
+from ascat.regrid.regrid import regrid_swath_ds
+from ascat.regrid.regrid import retrieve_or_store_grid_lut
+from ascat.regrid.regrid import grid_to_regular_grid
+
+
+def parse_args_swath_regrid(args):
+    """
+    Parse command line arguments for regridding an ASCAT swath file to a regular grid.
+    """
+    parser = argparse.ArgumentParser(
+        description='Regrid an ASCAT swath file to a regular grid'
+    )
+    parser.add_argument('filepath', metavar='FILEPATH', help='Path to the data')
+    parser.add_argument('outpath', metavar='OUTPATH', help='Path to the output data')
+    parser.add_argument(
+        'regrid_deg',
+        metavar='REGRID_DEG',
+        help='Regrid the data to a regular grid with the given spacing in degrees'
+    )
+    parser.add_argument(
+        '--grid_store',
+        metavar='GRID_STORE',
+        help='Path to a directory for storing grids and lookup tables between them'
+    )
+    return parser.parse_args(args)
+
+
+def swath_regrid_main(cli_args):
+    """
+    Regrid an ASCAT swath file or directory of swath files to a regular grid and write
+    the results to disk.
+    """
+    args = parse_args_swath_regrid(cli_args)
+    filepath = Path(args.filepath)
+    outpath = Path(args.outpath)
+    new_grid_size = float(args.regrid_deg)
+    new_grid = None
+
+    if filepath.is_dir():
+        files = filepath.glob("*.nc")
+    else:
+        files = [filepath]
+
+    if files is None:
+        raise ValueError("No .nc files found in the provided filepath.")
+
+    first_file = files[0]
+    product = swath_io_catalog[get_swath_product_id(str(first_file.name))]
+    old_grid = product.grid
+    old_grid_size = product.grid_sampling_km
+
+    if args.grid_store:
+        grid_store = args.grid_store
+    else:
+        grid_store = None
+
+    for file in files:
+        if new_grid is None:
+            new_grid, _, new_grid_lut = grid_to_regular_grid(
+                old_grid,
+                new_grid_size
+            )
+        else:
+            old_grid_id = f"fib_grid_{old_grid_size}km"
+            new_grid_id = f"reg_grid_{args.regrid_deg}deg"
+            new_grid, _, new_grid_lut = retrieve_or_store_grid_lut(
+                grid_store,
+                old_grid,
+                old_grid_id,
+                new_grid_id,
+                new_grid_size
+            )
+        swath_ds = xr.open_dataset(file, decode_cf=False, mask_and_scale=False)
+        regridded_ds = regrid_swath_ds(swath_ds, new_grid, new_grid_lut)
+        regridded_ds.to_netcdf(outpath / file.name)
+
+
+def run_swath_regrid():
+    """ Run command line interface for temporal aggregation of ASCAT data. """
+    swath_regrid_main(sys.argv[1:])

--- a/src/ascat/regrid/regrid.py
+++ b/src/ascat/regrid/regrid.py
@@ -25,10 +25,16 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from pathlib import Path
+
+import numpy as np
+
 from pygeogrids.grids import genreg_grid
+from pygeogrids.netcdf import save_grid, load_grid
 
 
 # move this to pygeogrids
+
 def grid_to_regular_grid(old_grid, new_grid_size):
     """ Create a regular grid of a given size and a lookup table from it to another grid.
 
@@ -41,12 +47,72 @@ def grid_to_regular_grid(old_grid, new_grid_size):
     """
     new_grid = genreg_grid(new_grid_size, new_grid_size)
     old_grid_lut = new_grid.calc_lut(old_grid)
-    return new_grid, old_grid_lut
+    new_grid_lut = old_grid.calc_lut(new_grid)
+    return new_grid, old_grid_lut, new_grid_lut
 
 
-def regrid_xarray_ds(ds, new_grid, ds_grid_lut):
+def retrieve_or_store_grid_lut(
+        store_path,
+        old_grid,
+        old_grid_id,
+        new_grid_id,
+        regrid_degrees
+):
+    """Get a grid and its lookup table from a store directory or create, store, and return them.
+
+    Parameters
+    ----------
+    store_path : str
+        Path to the store directory.
+    old_grid : pygeogrids.BasicGrid
+        The old grid.
+    old_grid_id : str
+        The old grid's id.
+    new_grid_id : str
+        The new grid's id.
+    regrid_degrees : int
+        The size of the new grid in degrees.
     """
-    Convert a dataset from a Fibonacci grid to a standard grid.
+    store_path = Path(store_path)
+    old_lut_path = store_path / f"lut_{old_grid_id}_{new_grid_id}.npy"
+    new_lut_path = store_path / f"lut_{new_grid_id}_{old_grid_id}.npy"
+    grid_path = store_path / f"grid_{new_grid_id}.nc"
+    if grid_path.exists() and cur_new_lut_path.exists() and new_cur_lut_path.exists():
+        new_grid = load_grid(grid_path)
+        old_grid_lut = np.load(old_lut_path, allow_pickle=True)
+        new_grid_lut = np.load(new_lut_path, allow_pickle=True)
+
+    else:
+        new_grid, old_grid_lut, new_grid_lut = grid_to_regular_grid(old_grid,
+                                                                    regrid_degrees)
+        old_lut_path.parent.mkdir(parents=True, exist_ok=True)
+        new_lut_path.parent.mkdir(parents=True, exist_ok=True)
+        old_grid_lut.dump(old_lut_path)
+        new_grid_lut.dump(new_lut_path)
+        save_grid(grid_path, new_grid)
+
+    return new_grid, old_grid_lut, new_grid_lut
+
+def regrid_swath_ds(ds, new_grid, new_grid_lut):
+    """Convert a swath dataset's location_ids to their nearest neighbors in a new grid."""
+    new_gpis = new_grid_lut[ds["location_id"].values]
+    new_lons = new_grid.arrlon[new_gpis]
+    new_lats = new_grid.arrlat[new_gpis]
+    ds["location_id"] = ("obs", new_gpis)
+    ds["longitude"] = ("obs", new_lons)
+    ds["latitude"] = ("obs", new_lats)
+    return ds
+
+
+def regrid_global_raster_ds(ds, new_grid, old_grid_lut):
+    """Convert a global dataset from a Fibonacci grid to a standard grid.
+
+    Assumes the input dataset has a unique location_id dimension.
+
+    The output data will cover the entire globe and have lat and lon dimensions. The data
+    for each point will be taken from the nearest location on the old grid. If multiple
+    new points have the same nearest location, that data will be duplicated for each. If
+    the nearest old location is NaN or does not exist in `ds`, the new point will be NaN.
 
     Parameters
     ----------
@@ -65,7 +131,7 @@ def regrid_xarray_ds(ds, new_grid, ds_grid_lut):
     new_gpis = new_grid.gpis
     new_lons = new_grid.arrlon
     new_lats = new_grid.arrlat
-    nearest_ds_gpis = ds_grid_lut[new_gpis]
+    nearest_ds_gpis = old_grid_lut[new_gpis]
     ds = ds.reindex(location_id=nearest_ds_gpis)
 
     # put the new gpi/lon/lat data onto the grouped_ds as well

--- a/src/ascat/regrid/scratch.py
+++ b/src/ascat/regrid/scratch.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from datetime import datetime
+import numpy as np
+from ascat.read_native.ragged_array_ts import SwathFileCollection
+from flox.xarray import xarray_reduce
+from matplotlib import pyplot as plt
+from cmcrameri import cm as cmc
+import cartopy.crs as ccrs
+from ascat.regrid.regrid import grid_to_regular_grid
+
+def simple_map(lons, lats, color_var, cmap, dates=None, cbar_label=None):
+    plt.figure()
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    ax.coastlines()
+    gl = ax.gridlines(draw_labels=True)
+    gl.bottom_labels = False
+    gl.right_labels = False
+    ax.set_extent([lons.min()-5, lons.max()+5, lats.min()-5, lats.max()+5])
+    # ax.set_extent([-10, 30, 35, 65])
+    plt.scatter(
+        lons,
+        lats,
+        c=color_var,
+        cmap=cmap,
+        s=1,
+        # alpha=0.8,
+        # clim=(0, 100)
+    )
+    if cbar_label is None:
+        cbar_label = (
+            f"Average {color_var.long_name}\n"
+            f"({color_var.units})\n"
+        )
+    if dates is not None:
+        cbar_label += f"\n{np.datetime_as_string(dates[0], unit='s')} - {np.datetime_as_string(dates[1], unit='s')}"
+
+    plt.colorbar(label=(cbar_label),
+                 shrink=0.5,
+                 pad=0.05,
+                 orientation="horizontal"
+    )
+    plt.tight_layout()
+
+def plot_ds(ds, grid):
+    ds["location_id"].load()
+    avg_ssm_flox = xarray_reduce(ds["surface_soil_moisture"], ds["location_id"], func="mean").load()
+    print(avg_ssm_flox)
+    lons, lats = grid.gpi2lonlat(avg_ssm_flox['location_id'].values)
+    simple_map(lons, lats, avg_ssm_flox, cmc.roma, dates=(ds.time.min(), ds.time.max()))
+
+def main():
+    name = 'W_IT-HSAF-ROME,SAT,SSM-ASCAT-METOPA-12.5km-H121_C_LIIB_20240117135900_20210101060000_20210101065959____.nc'
+    ungridded_path = Path('/home/charriso/p14/data-write/RADAR/hsaf/h121_v1.0/swaths/metop_a/2021/')
+    regridded_path = Path('/home/charriso/temp_py/')
+    ungridded = SwathFileCollection.from_product_id(ungridded_path, 'H121_v1.0')
+    regridded = SwathFileCollection.from_product_id(regridded_path, 'H121_v1.0')
+
+    # print(ungridded.get_filenames(start_dt=datetime(2021, 1, 1, 5), end_dt=datetime(2021, 1, 1, 7)))
+
+    ug_ds = ungridded.read(date_range=(datetime(2021, 1, 1, 6), datetime(2021, 1, 1, 7)))
+    rg_ds = regridded.read(date_range=(datetime(2021, 1, 1, 5), datetime(2021, 1, 1, 7)))
+
+    new_grid, _, _ = grid_to_regular_grid(ungridded.grid, 0.1)
+    plot_ds(ug_ds, ungridded.grid)
+    plot_ds(rg_ds, new_grid)
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds the option --regrid to the aggregator CLI. The value passed will determine the size of a regular grid to regrid the data to after aggregation.

Data is first aggregated by time chunk to the GPIs of the original grid, then for each point in the new grid, the aggregated data from the nearest point in the original grid is taken (if data exists at the nearest point in the original grid - otherwise it is set to NaN).

Output is a single netcdf file for each timechunk, with `time`, `lon`, and `lat` dimensions (raster data). These can be opened together as a datacube using xarray's `open_mfdataset` with `concat_dim="time"` and `combine="nested"`.

Might be nice to add an option to write to a single netCDF or even Zarr, rather than several netCDFs?