### PR TITLE
Catch any exception on cell collection date regex

### DIFF
--- a/src/ascat/read_native/ragged_array_ts.py
+++ b/src/ascat/read_native/ragged_array_ts.py
@@ -941,7 +941,7 @@ class CellFileCollection:
             start_date = dt.strptime(match.group("date1"), self.dir_date_format)
             end_date = dt.strptime(match.group("date2"), self.dir_date_format)
             return np.datetime64(start_date, "ns"), np.datetime64(end_date, "ns")
-        except ValueError:
+        except Exception:
             warnings.warn(
                 f"Could not determine date range for collection '{self.path.stem}'"
                 " from directory name."


### PR DESCRIPTION
Making a cell collection from a non-dated directory works currently only if the directory name format matches the "{date1}_{date2}" regex. That match should be allowed to fail and be handled. This change catches any exception in `ascat.read_native.ragged_array_ts.CellFileCollection.date_range`, rather than just the ValueError thrown when the regex matches the directory name but {date1} or {date2} is not actually a date, which is the current behavior.