### PR TITLE
Add `Filenames` base class for subclassing by readers; convert level 1&2 readers to use it

### DIFF
--- a/src/ascat/eumetsat/level1.py
+++ b/src/ascat/eumetsat/level1.py
@@ -30,10 +30,10 @@ Readers for ASCAT Level 1b data for various file formats.
 
 from pathlib import Path
 
-from ascat.read_native.nc import AscatL1bNcFile
-from ascat.read_native.hdf5 import AscatL1bHdf5File
-from ascat.read_native.bufr import AscatL1bBufrFile
-from ascat.read_native.eps_native import AscatL1bEpsFile
+from ascat.read_native.nc import AscatL1bNcFileGeneric
+from ascat.read_native.hdf5 import AscatL1bHdf5FileGeneric
+from ascat.read_native.bufr import AscatL1bBufrFileGeneric
+from ascat.read_native.eps_native import AscatL1bEpsFileGeneric
 from ascat.utils import get_file_format
 from ascat.file_handling import ChronFiles
 
@@ -43,7 +43,7 @@ class AscatL1bFile:
     Class reading ASCAT Level 1b files.
     """
 
-    def __new__(cls, filename, file_format=None, read_generic=True):
+    def __new__(cls, filename, file_format=None):
         """
         Return an instance of the appropriate ASCAT Level 1b file reader.
 
@@ -62,15 +62,16 @@ class AscatL1bFile:
                 file_format = get_file_format(filename[0])
 
         if file_format in [".nat", ".nat.gz"]:
-            return AscatL1bEpsFile(filename, read_generic=read_generic)
+            return AscatL1bEpsFileGeneric(filename)
         elif file_format in [".nc", ".nc.gz"]:
-            return AscatL1bNcFile(filename, read_generic=read_generic)
+            return AscatL1bNcFileGeneric(filename)
         elif file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
-            return AscatL1bBufrFile(filename, read_generic=read_generic)
+            return AscatL1bBufrFileGeneric(filename)
         elif file_format in [".h5", ".h5.gz"]:
-            return AscatL1bHdf5File(filename, read_generic=read_generic)
+            return AscatL1bHdf5FileGeneric(filename)
         else:
             raise RuntimeError("ASCAT Level 1b file format unknown")
+
 
 
 class AscatL1bBufrFileList(ChronFiles):

--- a/src/ascat/eumetsat/level1.py
+++ b/src/ascat/eumetsat/level1.py
@@ -28,16 +28,13 @@
 Readers for ASCAT Level 1b data for various file formats.
 """
 
-import os
-from collections import defaultdict
-
-import numpy as np
+from pathlib import Path
 
 from ascat.read_native.nc import AscatL1bNcFile
 from ascat.read_native.hdf5 import AscatL1bHdf5File
 from ascat.read_native.bufr import AscatL1bBufrFile
 from ascat.read_native.eps_native import AscatL1bEpsFile
-from ascat.utils import get_toi_subset, get_roi_subset
+from ascat.utils import get_file_format
 from ascat.file_handling import ChronFiles
 
 
@@ -46,9 +43,9 @@ class AscatL1bFile:
     Class reading ASCAT Level 1b files.
     """
 
-    def __init__(self, filename, file_format=None):
+    def __new__(cls, filename, file_format=None, read_generic=True):
         """
-        Initialize.
+        Return an instance of the appropriate ASCAT Level 1b file reader.
 
         Parameters
         ----------
@@ -58,108 +55,22 @@ class AscatL1bFile:
             File format: ".nat", ".nc", ".bfr", ".h5" (default: None).
             If None file format will be guessed based on the file ending.
         """
-        self.filename = filename
-        self.fid = None
-
         if file_format is None:
-            file_format = get_file_format(self.filename)
+            if isinstance(filename, (str, Path)):
+                file_format = get_file_format(filename)
+            else:
+                file_format = get_file_format(filename[0])
 
-        self.file_format = file_format
-
-        if self.file_format in [".nat", ".nat.gz"]:
-            self.fid = AscatL1bEpsFile(self.filename)
-        elif self.file_format in [".nc", ".nc.gz"]:
-            self.fid = AscatL1bNcFile(self.filename)
-        elif self.file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
-            self.fid = AscatL1bBufrFile(self.filename)
-        elif self.file_format in [".h5", ".h5.gz"]:
-            self.fid = AscatL1bHdf5File(self.filename)
+        if file_format in [".nat", ".nat.gz"]:
+            return AscatL1bEpsFile(filename, read_generic=read_generic)
+        elif file_format in [".nc", ".nc.gz"]:
+            return AscatL1bNcFile(filename, read_generic=read_generic)
+        elif file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
+            return AscatL1bBufrFile(filename, read_generic=read_generic)
+        elif file_format in [".h5", ".h5.gz"]:
+            return AscatL1bHdf5File(filename, read_generic=read_generic)
         else:
             raise RuntimeError("ASCAT Level 1b file format unknown")
-
-    def read(self, toi=None, roi=None, generic=True, to_xarray=False, **kwargs):
-        """
-        Read ASCAT Level 1b data.
-
-        Parameters
-        ----------
-        toi : tuple of datetime, optional
-            Filter data for given time of interest (default: None).
-            e.g. (datetime(2020, 1, 1, 12), datetime(2020, 1, 2))
-        roi : tuple of 4 float, optional
-            Filter data for region of interest (default: None).
-            e.g. latmin, lonmin, latmax, lonmax
-        generic : boolean, optional
-            Convert original data field names to generic field names
-            (default: True).
-        to_xarray : boolean, optional
-            Convert data to xarray.Dataset otherwise numpy.ndarray will be
-            returned (default: False).
-
-        Returns
-        -------
-        data : xarray.Dataset or numpy.ndarray
-            ASCAT data.
-        metadata : dict
-            Metadata.
-        """
-        data, metadata = self.fid.read(generic=generic, to_xarray=to_xarray, **kwargs)
-
-        if toi:
-            data = get_toi_subset(data, toi)
-
-        if roi:
-            data = get_roi_subset(data, roi)
-
-        return data, metadata
-
-    def read_period(self, dt_start, dt_end, **kwargs):
-        """
-        Read interval.
-
-        Parameters
-        ----------
-        dt_start : datetime
-            Start datetime.
-        dt_end : datetime
-            End datetime.
-
-        Returns
-        -------
-        data : xarray.Dataset or numpy.ndarray
-            ASCAT data.
-        metadata : dict
-            Metadata.
-        """
-        return self.read(toi=(dt_start, dt_end), **kwargs)
-
-    def close(self):
-        """
-        Close file.
-        """
-        self.fid.close()
-
-
-def get_file_format(filename):
-    """
-    Try to guess the file format from the extension.
-
-    Parameters
-    ----------
-    filename : str
-        File name.
-
-    Returns
-    -------
-    file_format : str
-        File format indicator.
-    """
-    if os.path.splitext(filename)[1] == ".gz":
-        file_format = os.path.splitext(os.path.splitext(filename)[0])[1]
-    else:
-        file_format = os.path.splitext(filename)[1]
-
-    return file_format
 
 
 class AscatL1bBufrFileList(ChronFiles):
@@ -224,30 +135,6 @@ class AscatL1bBufrFileList(ChronFiles):
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
 
-    def _merge_data(self, data):
-        """
-        Merge data.
-
-        Parameters
-        ----------
-        data : list
-            List of array.
-
-        Returns
-        -------
-        data : numpy.ndarray or tuple
-            Data (and Metdata).
-        """
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                data = np.hstack([element[0] for element in data])
-                data = (data, metadata)
-            else:
-                data = np.hstack(data)
-
-        return data
-
 
 class AscatL1bNcFileList(ChronFiles):
     """
@@ -309,30 +196,6 @@ class AscatL1bNcFileList(ChronFiles):
         sf_write_fmt = sf_read_fmt
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
-
-    def _merge_data(self, data):
-        """
-        Merge data.
-
-        Parameters
-        ----------
-        data : list
-            List of array.
-
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                data = np.hstack([element[0] for element in data])
-                data = (data, metadata)
-            else:
-                data = np.hstack(data)
-
-        return data
 
 
 class AscatL1bEpsFileList(ChronFiles):
@@ -396,57 +259,6 @@ class AscatL1bEpsFileList(ChronFiles):
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
 
-    # def _merge_data(self, data):
-    #     """
-    #     Merge data.
-
-    #     Parameters
-    #     ----------
-    #     data : list
-    #         List of array.
-
-    #     Returns
-    #     -------
-    #     data : numpy.ndarray
-    #         Data.
-    #     """
-    #     metadata = {}
-
-    #     left_beams = ["lf-vv", "lm-vv", "la-vv"]
-    #     right_beams = ["rf-vv", "rm-vv", "ra-vv"]
-    #     all_beams = left_beams + right_beams
-
-    #     if self.product == "szf":
-    #         if type(data) == list:
-    #             if type(data[0]) == tuple:
-    #                 metadata = [element[1] for element in data]
-    #                 merged_data = defaultdict(list)
-    #                 for beam in all_beams:
-    #                     for d in data:
-    #                         merged_data[beam].append(d[0].pop(beam))
-    #                     merged_data[beam] = np.hstack(merged_data[beam])
-    #             else:
-    #                 merged_data = defaultdict(list)
-    #                 for beam in all_beams:
-    #                     for d in data:
-    #                         merged_data[beam].append(d.pop(beam))
-    #                     merged_data[beam] = np.hstack(merged_data[beam])
-    #         else:
-    #             merged_data = data
-    #     else:
-    #         if type(data) == list:
-    #             if type(data[0]) == tuple:
-    #                 metadata = [element[1] for element in data]
-    #                 merged_data = np.hstack([element[0] for element in data])
-    #             else:
-    #                 merged_data = np.hstack(data)
-    #         else:
-    #             merged_data = data
-
-    #     merged_data = (merged_data, metadata)
-
-    #     return merged_data
-
 
 class AscatL1bHdf5FileList(ChronFiles):
     """
@@ -504,44 +316,3 @@ class AscatL1bHdf5FileList(ChronFiles):
         sf_write_fmt = sf_read_fmt
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
-
-    def _merge_data(self, data):
-        """
-        Merge data.
-
-        Parameters
-        ----------
-        data : list
-            List of array.
-
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        left_beams = ["lf-vv", "lm-vv", "la-vv"]
-        right_beams = ["rf-vv", "rm-vv", "ra-vv"]
-        all_beams = left_beams + right_beams
-
-        metadata = {}
-
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                merged_data = defaultdict(list)
-                for beam in all_beams:
-                    for d in data:
-                        merged_data[beam].append(d[0].pop(beam))
-                    merged_data[beam] = np.hstack(merged_data[beam])
-            else:
-                merged_data = defaultdict(list)
-                for beam in all_beams:
-                    for d in data:
-                        merged_data[beam].append(d.pop(beam))
-                    merged_data[beam] = np.hstack(merged_data[beam])
-        else:
-            merged_data = data
-
-        merged_data = (merged_data, metadata)
-
-        return merged_data

--- a/src/ascat/eumetsat/level1.py
+++ b/src/ascat/eumetsat/level1.py
@@ -396,56 +396,56 @@ class AscatL1bEpsFileList(ChronFiles):
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
 
-    def _merge_data(self, data):
-        """
-        Merge data.
+    # def _merge_data(self, data):
+    #     """
+    #     Merge data.
 
-        Parameters
-        ----------
-        data : list
-            List of array.
+    #     Parameters
+    #     ----------
+    #     data : list
+    #         List of array.
 
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        metadata = {}
+    #     Returns
+    #     -------
+    #     data : numpy.ndarray
+    #         Data.
+    #     """
+    #     metadata = {}
 
-        left_beams = ["lf-vv", "lm-vv", "la-vv"]
-        right_beams = ["rf-vv", "rm-vv", "ra-vv"]
-        all_beams = left_beams + right_beams
+    #     left_beams = ["lf-vv", "lm-vv", "la-vv"]
+    #     right_beams = ["rf-vv", "rm-vv", "ra-vv"]
+    #     all_beams = left_beams + right_beams
 
-        if self.product == "szf":
-            if type(data) == list:
-                if type(data[0]) == tuple:
-                    metadata = [element[1] for element in data]
-                    merged_data = defaultdict(list)
-                    for beam in all_beams:
-                        for d in data:
-                            merged_data[beam].append(d[0].pop(beam))
-                        merged_data[beam] = np.hstack(merged_data[beam])
-                else:
-                    merged_data = defaultdict(list)
-                    for beam in all_beams:
-                        for d in data:
-                            merged_data[beam].append(d.pop(beam))
-                        merged_data[beam] = np.hstack(merged_data[beam])
-            else:
-                merged_data = data
-        else:
-            if type(data) == list:
-                if type(data[0]) == tuple:
-                    metadata = [element[1] for element in data]
-                    merged_data = np.hstack([element[0] for element in data])
-                else:
-                    merged_data = np.hstack(data)
-            else:
-                merged_data = data
+    #     if self.product == "szf":
+    #         if type(data) == list:
+    #             if type(data[0]) == tuple:
+    #                 metadata = [element[1] for element in data]
+    #                 merged_data = defaultdict(list)
+    #                 for beam in all_beams:
+    #                     for d in data:
+    #                         merged_data[beam].append(d[0].pop(beam))
+    #                     merged_data[beam] = np.hstack(merged_data[beam])
+    #             else:
+    #                 merged_data = defaultdict(list)
+    #                 for beam in all_beams:
+    #                     for d in data:
+    #                         merged_data[beam].append(d.pop(beam))
+    #                     merged_data[beam] = np.hstack(merged_data[beam])
+    #         else:
+    #             merged_data = data
+    #     else:
+    #         if type(data) == list:
+    #             if type(data[0]) == tuple:
+    #                 metadata = [element[1] for element in data]
+    #                 merged_data = np.hstack([element[0] for element in data])
+    #             else:
+    #                 merged_data = np.hstack(data)
+    #         else:
+    #             merged_data = data
 
-        merged_data = (merged_data, metadata)
+    #     merged_data = (merged_data, metadata)
 
-        return merged_data
+    #     return merged_data
 
 
 class AscatL1bHdf5FileList(ChronFiles):

--- a/src/ascat/eumetsat/level2.py
+++ b/src/ascat/eumetsat/level2.py
@@ -379,26 +379,26 @@ class AscatL2EpsFileList(ChronFiles):
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
 
-    def _merge_data(self, data):
-        """
-        Merge data.
+    # def _merge_data(self, data):
+    #     """
+    #     Merge data.
 
-        Parameters
-        ----------
-        data : list
-            List of array.
+    #     Parameters
+    #     ----------
+    #     data : list
+    #         List of array.
 
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                data = np.hstack([element[0] for element in data])
-                data = (data, metadata)
-            else:
-                data = np.hstack(data)
+    #     Returns
+    #     -------
+    #     data : numpy.ndarray
+    #         Data.
+    #     """
+    #     if type(data) == list:
+    #         if type(data[0]) == tuple:
+    #             metadata = [element[1] for element in data]
+    #             data = np.hstack([element[0] for element in data])
+    #             data = (data, metadata)
+    #         else:
+    #             data = np.hstack(data)
 
-        return data
+    #     return data

--- a/src/ascat/eumetsat/level2.py
+++ b/src/ascat/eumetsat/level2.py
@@ -33,9 +33,9 @@ from pathlib import Path
 
 import numpy as np
 
-from ascat.read_native.nc import AscatL2NcFile
-from ascat.read_native.bufr import AscatL2BufrFile
-from ascat.read_native.eps_native import AscatL2EpsFile
+from ascat.read_native.nc import AscatL2NcFileGeneric
+from ascat.read_native.bufr import AscatL2BufrFileGeneric
+from ascat.read_native.eps_native import AscatL2EpsFileGeneric
 from ascat.utils import get_toi_subset, get_roi_subset
 from ascat.utils import get_file_format
 from ascat.file_handling import ChronFiles
@@ -46,7 +46,7 @@ class AscatL2File:
     Class reading ASCAT Level 2 files.
     """
 
-    def __new__(cls, filename, file_format=None, read_generic=True):
+    def __new__(cls, filename, file_format=None):
         """
         Initialize AscatL2File.
 
@@ -66,11 +66,11 @@ class AscatL2File:
                 file_format = get_file_format(filename[0])
 
         if file_format in [".nat", ".nat.gz"]:
-            return AscatL2EpsFile(filename, read_generic=read_generic)
+            return AscatL2EpsFileGeneric(filename)
         elif file_format in [".nc", ".nc.gz"]:
-            return AscatL2NcFile(filename, read_generic=read_generic)
+            return AscatL2NcFileGeneric(filename)
         elif file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
-            return AscatL2BufrFile(filename, read_generic=read_generic)
+            return AscatL2BufrFileGeneric(filename)
         else:
             raise RuntimeError("ASCAT Level 2 file format unknown")
 

--- a/src/ascat/eumetsat/level2.py
+++ b/src/ascat/eumetsat/level2.py
@@ -29,12 +29,15 @@ Readers for ASCAT Level 2 data for various file formats.
 """
 
 import os
+from pathlib import Path
+
 import numpy as np
 
 from ascat.read_native.nc import AscatL2NcFile
 from ascat.read_native.bufr import AscatL2BufrFile
 from ascat.read_native.eps_native import AscatL2EpsFile
 from ascat.utils import get_toi_subset, get_roi_subset
+from ascat.utils import get_file_format
 from ascat.file_handling import ChronFiles
 
 
@@ -43,7 +46,7 @@ class AscatL2File:
     Class reading ASCAT Level 2 files.
     """
 
-    def __init__(self, filename, file_format=None):
+    def __new__(cls, filename, file_format=None, read_generic=True):
         """
         Initialize AscatL2File.
 
@@ -55,105 +58,21 @@ class AscatL2File:
             File format: ".nat", ".nc", ".bfr", ".h5" (default: None).
             If None file format will be guessed based on the file ending.
         """
-        self.filename = filename
-        self.fid = None
 
         if file_format is None:
-            file_format = get_file_format(self.filename)
+            if isinstance(filename, (str, Path)):
+                file_format = get_file_format(filename)
+            else:
+                file_format = get_file_format(filename[0])
 
-        self.file_format = file_format
-
-        if self.file_format in [".nat", ".nat.gz"]:
-            self.fid = AscatL2EpsFile(self.filename)
-        elif self.file_format in [".nc", ".nc.gz"]:
-            self.fid = AscatL2NcFile(self.filename)
-        elif self.file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
-            self.fid = AscatL2BufrFile(self.filename)
+        if file_format in [".nat", ".nat.gz"]:
+            return AscatL2EpsFile(filename, read_generic=read_generic)
+        elif file_format in [".nc", ".nc.gz"]:
+            return AscatL2NcFile(filename, read_generic=read_generic)
+        elif file_format in [".bfr", ".bfr.gz", ".buf", "buf.gz"]:
+            return AscatL2BufrFile(filename, read_generic=read_generic)
         else:
             raise RuntimeError("ASCAT Level 2 file format unknown")
-
-    def read(self, toi=None, roi=None, generic=True, to_xarray=False):
-        """
-        Read ASCAT Level 2 data.
-
-        Parameters
-        ----------
-        toi : tuple of datetime, optional
-            Filter data for given time of interest (default: None).
-        roi : tuple of 4 float, optional
-            Filter data for region of interest (default: None).
-            e.g. latmin, lonmin, latmax, lonmax
-        generic : boolean, optional
-            Convert original data field names to generic field names
-            (default: True).
-        to_xarray : boolean, optional
-            Convert data to xarray.Dataset otherwise numpy.ndarray will be
-            returned (default: False).
-
-        Returns
-        -------
-        data : xarray.Dataset or numpy.ndarray
-            ASCAT data.
-        metadata : dict
-            Metadata.
-        """
-        data, metadata = self.fid.read(generic=generic, to_xarray=to_xarray)
-
-        if toi:
-            data = get_toi_subset(data, toi)
-
-        if roi:
-            data = get_roi_subset(data, roi)
-
-        return data, metadata
-
-    def read_period(self, dt_start, dt_end, **kwargs):
-        """
-        Read interval.
-
-        Parameters
-        ----------
-        dt_start : datetime
-            Start datetime.
-        dt_end : datetime
-            End datetime.
-
-        Returns
-        -------
-        data : xarray.Dataset or numpy.ndarray
-            ASCAT data.
-        metadata : dict
-            Metadata.
-        """
-        return self.read(toi=(dt_start, dt_end), **kwargs)
-
-    def close(self):
-        """
-        Close file.
-        """
-        self.fid.close()
-
-
-def get_file_format(filename):
-    """
-    Try to guess the file format from the extension.
-
-    Parameters
-    ----------
-    filename : str
-        File name.
-
-    Returns
-    -------
-    file_format : str
-        File format indicator.
-    """
-    if os.path.splitext(filename)[1] == ".gz":
-        file_format = os.path.splitext(os.path.splitext(filename)[0])[1]
-    else:
-        file_format = os.path.splitext(filename)[1]
-
-    return file_format
 
 
 class AscatL2BufrFileList(ChronFiles):
@@ -206,30 +125,6 @@ class AscatL2BufrFileList(ChronFiles):
         sf_write_fmt = sf_read_fmt
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
-
-    def _merge_data(self, data):
-        """
-        Merge data.
-
-        Parameters
-        ----------
-        data : list
-            List of array.
-
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                data = np.hstack([element[0] for element in data])
-                data = (data, metadata)
-            else:
-                data = np.hstack(data)
-
-        return data
 
 
 class AscatL2NcFileList(ChronFiles):
@@ -293,30 +188,6 @@ class AscatL2NcFileList(ChronFiles):
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
 
-    def _merge_data(self, data):
-        """
-        Merge data.
-
-        Parameters
-        ----------
-        data : list
-            List of array.
-
-        Returns
-        -------
-        data : numpy.ndarray
-            Data.
-        """
-        if type(data) == list:
-            if type(data[0]) == tuple:
-                metadata = [element[1] for element in data]
-                data = np.hstack([element[0] for element in data])
-                data = (data, metadata)
-            else:
-                data = np.hstack(data)
-
-        return data
-
 
 class AscatL2EpsFileList(ChronFiles):
     """
@@ -378,27 +249,3 @@ class AscatL2EpsFileList(ChronFiles):
         sf_write_fmt = sf_read_fmt
 
         return fn_read_fmt, sf_read_fmt, fn_write_fmt, sf_write_fmt
-
-    # def _merge_data(self, data):
-    #     """
-    #     Merge data.
-
-    #     Parameters
-    #     ----------
-    #     data : list
-    #         List of array.
-
-    #     Returns
-    #     -------
-    #     data : numpy.ndarray
-    #         Data.
-    #     """
-    #     if type(data) == list:
-    #         if type(data[0]) == tuple:
-    #             metadata = [element[1] for element in data]
-    #             data = np.hstack([element[0] for element in data])
-    #             data = (data, metadata)
-    #         else:
-    #             data = np.hstack(data)
-
-    #     return data

--- a/src/ascat/file_handling.py
+++ b/src/ascat/file_handling.py
@@ -439,22 +439,10 @@ class MultiFileHandler(metaclass=abc.ABCMeta):
         fn_read_fmt, sf_read_fmt, _, _ = self._fmt(*fmt_args, **fmt_kwargs)
         search_filename = self.ft.build_filename(fn_read_fmt, sf_read_fmt)
         filename = glob.glob(search_filename)
+        self._open(filename)
 
         data = None
-        if len(filename) == 0:
-            msg = f"File not found: {search_filename}"
-            if self.err:
-                raise IOError(msg)
-            else:
-                warnings.warn(msg)
-        elif len(filename) > 1:
-            msg = "Multiple files found"
-            if self.err:
-                raise RuntimeError(msg)
-            else:
-                warnings.warn(msg)
-        else:
-            data = self.read_file(filename[0], cls_kwargs)
+        data = self.fid.read(**cls_kwargs)
 
         return data
 
@@ -824,8 +812,174 @@ class ChronFiles(MultiFileHandler):
 
         return data
 
+class Filenames:
+    """
+    A class to handle operations on multiple filenames.
 
-class Csv:
+    This class provides methods for reading from, writing to, and merging data from multiple files.
+    """
+
+    def __init__(self, filenames):
+        """
+        Initialize Filenames.
+
+        Parameters
+        ----------
+        filenames : str, Path, or list
+            File path(s) to be handled.
+        """
+        if isinstance(filenames, (str, Path)):
+            filenames = [filenames]
+        elif not isinstance(filenames, list):
+            raise ValueError("filenames must be a string or list of strings.")
+
+        self.filenames = [Path(f) for f in filenames]
+
+    def _read(self, filename, **kwargs):
+        """
+        Read data from a single file.
+
+        This method should be implemented by subclasses.
+
+        Parameters
+        ----------
+        filename : Path
+            The file to read from.
+        **kwargs : dict
+            Additional keyword arguments for reading.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented in a subclass.
+        """
+        raise NotImplementedError
+
+    def _merge(self, data, **kwargs):
+        """
+        Merge multiple data objects.
+
+        This method should be implemented by subclasses.
+
+        Parameters
+        ----------
+        data : list
+            List of data objects to merge.
+        **kwargs : dict
+            Additional keyword arguments for merging.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented in a subclass.
+        """
+        raise NotImplementedError
+
+    def _write(self, data, filename, **kwargs):
+        """
+        Write data to a single file.
+
+        This method should be implemented by subclasses.
+
+        Parameters
+        ----------
+        data : object
+            The data to write.
+        filename : Path
+            The file to write to.
+        **kwargs : dict
+            Additional keyword arguments for writing.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented in a subclass.
+        """
+        raise NotImplementedError
+
+    def write(self, data):
+        """
+        Write data to file.
+
+        If there's only one filename, write provided data to that file.
+
+        Parameters
+        ----------
+        data : object
+            The data to write.
+
+        TODO: Add support for writing to multiple files by passing a list of data and
+        checking if the number of data objects matches the number of filenames.
+        """
+        n_filenames = len(self.filenames)
+        if n_filenames == 1:
+            filename = self.filenames[0]
+            filename.parent.mkdir(parents=True, exist_ok=True)
+            self._write(data, filename)
+        # elif n_filenames > 1:
+        #     if len(data) == n_filenames:
+        #         for f in self.filenames:
+        #             f.parent.mkdir(parents=True, exist_ok=True)
+        #             self.write(data, f)
+
+    def read(self, **kwargs):
+        """
+        Read all data from files.
+
+        Returns
+        -------
+        object
+            Merged data from all files.
+        """
+        data = [d for d in self.iter_read(**kwargs)]
+        data = self.merge(data)
+        return data
+
+    def iter_read(self, **kwargs):
+        """
+        Iterate over all files and yield data.
+
+        Yields
+        ------
+        object
+            Data read from each file.
+        """
+        for filename in self.filenames:
+            yield self._read(filename, **kwargs)
+
+    def merge(self, data):
+        """
+        Merge data from multiple data objects.
+
+        Parameters
+        ----------
+        data : list
+            List of data objects.
+
+        Returns
+        -------
+        object
+            Merged data, or None if the input list is empty.
+        """
+        if len(data) > 1:
+            data = self._merge(data)
+        elif len(data) == 1:
+            data = data[0]
+        else:
+            data = None
+
+        return data
+
+    def close(self):
+        """
+        Close file(s).
+
+        This method can be overridden in subclasses if necessary.
+        """
+        pass
+
+
+class CsvFile(Filenames):
     """
     Read and write single CSV file.
     """
@@ -841,8 +995,8 @@ class Csv:
         mode : str, optional
             File opening mode.
         """
-        self.filename = filename
         self.mode = mode
+        super().__init__(filename)
 
     def header2dtype(self, header):
         """
@@ -875,16 +1029,16 @@ class Csv:
 
         return np.dtype(dtype_list)
 
-    def read(self):
+    def _read(self, filename):
         """
         Read data from CSV file.
 
         Parameters
         ----------
-        timestamp : datetime
-            Time stamp.
+        filename : str
+            Filename.
         """
-        with open(self.filename) as fid:
+        with open(filename) as fid:
             header = fid.readline()
             dtype = self.header2dtype(header)
             data = np.loadtxt(fid, dtype)
@@ -917,7 +1071,7 @@ class Csv:
 
         return data
 
-    def write(self, data):
+    def _write(self, data, filename):
         """
         Write data to CSV file.
 
@@ -927,10 +1081,10 @@ class Csv:
             Data.
         """
         header = data.dtype.__repr__()
-        np.savetxt(self.filename, data, fmt="%s", header=header)
+        np.savetxt(filename, data, fmt="%s", header=header)
 
     @staticmethod
-    def merge(data):
+    def _merge(data):
         """
         Merge data.
 
@@ -964,7 +1118,7 @@ class CsvFiles(ChronFiles):
         fn_templ = "prefix_{date}_{now}_postfix.csv"
         sf_templ = {"Y": "{year}", "M": "{month}"}
 
-        super().__init__(root_path, Csv, fn_templ, sf_templ=sf_templ)
+        super().__init__(root_path, CsvFile, fn_templ, sf_templ=sf_templ)
 
     def _fmt(self, timestamp):
         """

--- a/src/ascat/h_saf.py
+++ b/src/ascat/h_saf.py
@@ -42,6 +42,7 @@ except ImportError:
         'pygrib can not be imported GRIB files (H14) can not be read.')
 
 from ascat.file_handling import ChronFiles
+from ascat.file_handling import Filenames
 from ascat.eumetsat.level2 import AscatL2File
 from ascat.read_native.cdr import AscatGriddedNcTs
 
@@ -129,7 +130,7 @@ class AscatNrtBufrFileList(ChronFiles):
         return np.hstack(data)
 
 
-class H14Grib:
+class H14Grib(Filenames):
     """
     Class reading H14 soil moisture in GRIB format.
     """
@@ -150,7 +151,7 @@ class H14Grib:
         metadata_fields: list, optional
             fields of the message to put into the metadata dictionary.
         """
-        self.filename = filename
+        super().__init__(filename)
         self.expand_grid = expand_grid
         self.metadata_fields = metadata_fields
         self.pygrib1 = True
@@ -158,7 +159,7 @@ class H14Grib:
         if int(pygrib.__version__[0]) > 1:
             self.pygrib1 = False
 
-    def read(self, timestamp=None):
+    def _read(self, filename, timestamp=None):
         """
         Read specific image for given datetime timestamp.
 
@@ -194,7 +195,7 @@ class H14Grib:
         data = {}
         metadata = {}
 
-        with pygrib.open(self.filename) as grb:
+        with pygrib.open(filename) as grb:
             for i, message in enumerate(grb):
                 message.expand_grid(self.expand_grid)
                 if i == 1:
@@ -211,9 +212,6 @@ class H14Grib:
                 metadata[param_names[message['parameterName']]] = md
 
         return data
-
-    def close(self):
-        pass
 
 
 class H14GribFileList(ChronFiles):

--- a/src/ascat/read_native/__init__.py
+++ b/src/ascat/read_native/__init__.py
@@ -1,0 +1,1 @@
+from .base import AscatFile

--- a/src/ascat/read_native/base.py
+++ b/src/ascat/read_native/base.py
@@ -34,7 +34,7 @@ class AscatFile(Filenames):
     """
     Class reading ASCAT files.
     """
-    def __init__(self, filename, read_generic=False):
+    def __init__(self, filename):
         """
         Initialize AscatFile.
 
@@ -42,14 +42,10 @@ class AscatFile(Filenames):
         ----------
         filename : str
             Filename.
-        read_generic : boolean, optional
-            Convert original data field names to generic field names by default when
-            reading (default: False).
         """
         super().__init__(filename)
-        self.read_generic = read_generic
 
-    def read(self, toi=None, roi=None, generic=None, to_xarray=False, **kwargs):
+    def read(self, toi=None, roi=None, **kwargs):
         """
         Read ASCAT Level 1b data.
 
@@ -61,12 +57,6 @@ class AscatFile(Filenames):
         roi : tuple of 4 float, optional
             Filter data for region of interest (default: None).
             e.g. latmin, lonmin, latmax, lonmax
-        generic : boolean, optional
-            Convert original data field names to generic field names. Defaults
-            to the value of self.read_generic.
-        to_xarray : boolean, optional
-            Convert data to xarray.Dataset otherwise numpy.ndarray will be
-            returned (default: False).
 
         Returns
         -------
@@ -74,22 +64,8 @@ class AscatFile(Filenames):
             ASCAT data.
         metadata : dict
             Metadata.
-
-        Notes
-        -----
-        TODO Figure out if subsetting should be done before or after merging,
-        and implement if necessary.
         """
-        if generic is None:
-            if to_xarray:
-                generic = True
-            else:
-                generic = self.read_generic
-
-        data, metadata = super().read(generic=generic, to_xarray=to_xarray, **kwargs)
-
-        if to_xarray and generic:
-            data = mask_dtype_nans(data)
+        data, metadata = super().read(**kwargs)
 
         if toi:
             data = get_toi_subset(data, toi)

--- a/src/ascat/read_native/base.py
+++ b/src/ascat/read_native/base.py
@@ -27,6 +27,7 @@
 
 from ascat.file_handling import Filenames
 from ascat.utils import get_toi_subset, get_roi_subset
+from ascat.utils import mask_dtype_nans
 
 
 class AscatFile(Filenames):
@@ -80,9 +81,15 @@ class AscatFile(Filenames):
         and implement if necessary.
         """
         if generic is None:
-            generic = self.read_generic
+            if to_xarray:
+                generic = True
+            else:
+                generic = self.read_generic
 
         data, metadata = super().read(generic=generic, to_xarray=to_xarray, **kwargs)
+
+        if to_xarray and generic:
+            data = mask_dtype_nans(data)
 
         if toi:
             data = get_toi_subset(data, toi)

--- a/src/ascat/read_native/base.py
+++ b/src/ascat/read_native/base.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2024, TU Wien, Department of Geodesy and Geoinformation
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of TU Wien, Department of Geodesy and Geoinformation
+#      nor the names of its contributors may be used to endorse or promote
+#      products derived from this software without specific prior written
+#      permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL TU WIEN DEPARTMENT OF GEODESY AND
+# GEOINFORMATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from ascat.file_handling import Filenames
+from ascat.utils import get_toi_subset, get_roi_subset
+
+
+class AscatFile(Filenames):
+    """
+    Class reading ASCAT files.
+    """
+    def __init__(self, filename, read_generic=False):
+        """
+        Initialize AscatFile.
+
+        Parameters
+        ----------
+        filename : str
+            Filename.
+        read_generic : boolean, optional
+            Convert original data field names to generic field names by default when
+            reading (default: False).
+        """
+        super().__init__(filename)
+        self.read_generic = read_generic
+
+    def read(self, toi=None, roi=None, generic=None, to_xarray=False, **kwargs):
+        """
+        Read ASCAT Level 1b data.
+
+        Parameters
+        ----------
+        toi : tuple of datetime, optional
+            Filter data for given time of interest (default: None).
+            e.g. (datetime(2020, 1, 1, 12), datetime(2020, 1, 2))
+        roi : tuple of 4 float, optional
+            Filter data for region of interest (default: None).
+            e.g. latmin, lonmin, latmax, lonmax
+        generic : boolean, optional
+            Convert original data field names to generic field names. Defaults
+            to the value of self.read_generic.
+        to_xarray : boolean, optional
+            Convert data to xarray.Dataset otherwise numpy.ndarray will be
+            returned (default: False).
+
+        Returns
+        -------
+        data : xarray.Dataset or numpy.ndarray
+            ASCAT data.
+        metadata : dict
+            Metadata.
+
+        Notes
+        -----
+        TODO Figure out if subsetting should be done before or after merging,
+        and implement if necessary.
+        """
+        if generic is None:
+            generic = self.read_generic
+
+        data, metadata = super().read(generic=generic, to_xarray=to_xarray, **kwargs)
+
+        if toi:
+            data = get_toi_subset(data, toi)
+
+        if roi:
+            data = get_roi_subset(data, roi)
+
+        return data, metadata
+
+    def read_period(self, dt_start, dt_end, **kwargs):
+        """
+        Read interval.
+
+        Parameters
+        ----------
+        dt_start : datetime
+            Start datetime.
+        dt_end : datetime
+            End datetime.
+
+        Returns
+        -------
+        data : xarray.Dataset or numpy.ndarray
+            ASCAT data.
+        metadata : dict
+            Metadata.
+        """
+        return self.read(toi=(dt_start, dt_end), **kwargs)

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -40,7 +40,6 @@ except ImportError:
     pass
 
 from ascat.utils import tmp_unzip
-from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 
 bufr_nan = 1.7e+38
@@ -178,7 +177,6 @@ class AscatL1bBufrFile(AscatFile):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
-            data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []
@@ -455,7 +453,6 @@ class AscatL2BufrFile(AscatFile):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
-            data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -41,15 +41,13 @@ except ImportError:
 
 from ascat.utils import tmp_unzip
 from ascat.utils import mask_dtype_nans
-from ascat.utils import float32_nan
 from ascat.utils import uint8_nan
 from ascat.utils import uint16_nan
+from ascat.utils import int32_nan
+from ascat.utils import float32_nan
 from ascat.read_native import AscatFile
 
 bufr_nan = 1.7e+38
-
-# TODO correct this? now that we like to use the range min for signed integer nans
-int32_nan = np.iinfo(np.int32).max
 
 nan_val_dict = {
     np.float32: float32_nan,

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -212,7 +212,9 @@ class AscatL1bBufrFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                data = xr.concat(data, dim="obs")
+                data = xr.concat(data,
+                                 dim="obs",
+                                 combine_attrs="drop_conflicts")
             else:
                 data = np.hstack(data)
             data = (data, metadata)
@@ -498,7 +500,9 @@ class AscatL2BufrFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                data = xr.concat(data, dim="obs")
+                data = xr.concat(data,
+                                 dim="obs",
+                                 combine_attrs="drop_conflicts")
             else:
                 data = np.hstack(data)
             data = (data, metadata)

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -41,12 +41,14 @@ except ImportError:
 
 from ascat.utils import tmp_unzip
 from ascat.utils import mask_dtype_nans
+from ascat.utils import float32_nan
+from ascat.utils import uint8_nan
+from ascat.utils import uint16_nan
 from ascat.read_native import AscatFile
 
 bufr_nan = 1.7e+38
-float32_nan = -999999.
-uint8_nan = np.iinfo(np.uint8).max
-uint16_nan = np.iinfo(np.uint16).max
+
+# TODO correct this? now that we like to use the range min for signed integer nans
 int32_nan = np.iinfo(np.int32).max
 
 nan_val_dict = {

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -40,6 +40,7 @@ except ImportError:
     pass
 
 from ascat.utils import tmp_unzip
+from ascat.utils import mask_dtype_nans
 
 bufr_nan = 1.7e+38
 float32_nan = -999999.
@@ -175,6 +176,7 @@ class AscatL1bBufrFile:
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []
@@ -431,6 +433,7 @@ class AscatL2BufrFile():
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []

--- a/src/ascat/read_native/bufr.py
+++ b/src/ascat/read_native/bufr.py
@@ -40,6 +40,7 @@ except ImportError:
     pass
 
 from ascat.utils import tmp_unzip
+from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 
 bufr_nan = 1.7e+38
@@ -54,7 +55,6 @@ nan_val_dict = {
     np.uint16: uint16_nan,
     np.int32: int32_nan
 }
-
 
 class AscatL1bBufrFile(AscatFile):
     """
@@ -177,6 +177,8 @@ class AscatL1bBufrFile(AscatFile):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            if generic:
+                data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []
@@ -221,6 +223,13 @@ class AscatL1bBufrFile(AscatFile):
         else:
             data = np.hstack(data)
         return data
+
+class AscatL1bBufrFileGeneric(AscatL1bBufrFile):
+    """
+    The same as AscatL1bBufrFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 
 def conv_bufrl1b_generic(data, metadata):
@@ -455,6 +464,8 @@ class AscatL2BufrFile(AscatFile):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            if generic:
+                data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []
@@ -510,6 +521,12 @@ class AscatL2BufrFile(AscatFile):
             data = np.hstack(data)
         return data
 
+class AscatL2BufrFileGeneric(AscatL2BufrFile):
+    """
+    The same as AscatL1bBufrFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 def conv_bufrl2_generic(data, metadata):
     """

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -44,6 +44,7 @@ from datetime import timedelta
 from ascat.utils import get_toi_subset, get_roi_subset
 from ascat.utils import get_bit, set_bit
 from ascat.utils import dtype_to_nan
+from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 
 short_cds_time = np.dtype([("day", ">u2"), ("time", ">u4")])
@@ -158,7 +159,6 @@ class AscatL1bEpsSzfFile(AscatFile):
 
         return merged_data
 
-
 class AscatL1bEpsFile(AscatFile):
     """
     ASCAT Level 1b EPS Native reader class.
@@ -243,6 +243,13 @@ class AscatL1bEpsFile(AscatFile):
 
         return merged_data
 
+class AscatL1bEpsFileGeneric(AscatL1bEpsFile):
+    """
+    The same as AscatL1bEpsFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
+
 
 class AscatL2EpsFile(AscatFile):
     """
@@ -297,6 +304,12 @@ class AscatL2EpsFile(AscatFile):
 
         return data
 
+class AscatL2EpsFileGeneric(AscatL2EpsFile):
+    """
+    The same as AscatL1bEpsFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 class EPSProduct:
     """
@@ -1123,6 +1136,8 @@ def read_eps_l1b(filename,
                     coords[cf] = sub_data.pop(cf)
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords, attrs=metadata)
+                if generic:
+                    data = mask_dtype_nans(data)
             else:
                 # collect dtype info
                 dtype = []
@@ -1196,6 +1211,8 @@ def read_eps_l1b(filename,
                 coords[cf] = data.pop(cf)
 
             ds = xr.Dataset(data, coords=coords, attrs=metadata)
+            if generic:
+                data = mask_dtype_nans(data)
         else:
             # collect dtype info
             dtype = []
@@ -1286,6 +1303,8 @@ def read_eps_l2(filename, generic=False, to_xarray=False, return_ptype=False):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            if generic:
+                data = mask_dtype_nans(data)
 
         else:
             # collect dtype info

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -1107,6 +1107,8 @@ def read_eps_l1b(filename,
                         dim = ["obs"]
                     elif len(data[var_name].shape) == 2:
                         dim = ["obs", "echo"]
+                    if var_name == "time":
+                        data[var_name] = data[var_name].astype("datetime64[ns]")
 
                     sub_data[var_name] = (dim, data[var_name][subset])
 
@@ -1179,6 +1181,8 @@ def read_eps_l1b(filename,
                     dim = ["obs"]
                 elif len(data[k].shape) == 2:
                     dim = ["obs", "beam"]
+                if k == "time":
+                    data[k] = data[k].astype("datetime64[ns]")
 
                 data[k] = (dim, data[k])
 
@@ -1267,6 +1271,8 @@ def read_eps_l2(filename, generic=False, to_xarray=False, return_ptype=False):
                     dim = ["obs"]
                 elif len(data[k].shape) == 2:
                     dim = ["obs", "beam"]
+                if k == "time":
+                    data[k] = data[k].astype("datetime64[ns]")
 
                 data[k] = (dim, data[k])
 

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -284,7 +284,6 @@ class AscatL2EpsFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                print(data)
                 data = xr.concat(data, dim="obs")
             else:
                 data = np.hstack(data)

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -1707,14 +1707,14 @@ def read_smx_fmv_12(eps_file):
                                  raw_data["UTC_LINE_NODES"].flatten()["time"])
     data["jd"] = ascat_time[idx_nodes]
 
-    fields = [("sigma0_trip", long_nan), ("inc_angle_trip", uint_nan),
-              ("azi_angle_trip", int_nan), ("kp", uint_nan),
-              ("f_land", uint_nan)]
+    fields = [("sigma0_trip", long_nan, long_nan), ("inc_angle_trip", uint_nan, uint_nan),
+              ("azi_angle_trip", int_nan, int_nan), ("kp", uint_nan, uint_nan),
+              ("f_land", uint_nan, float32_nan)]
 
-    for f, nan_val in fields:
+    for f, nan_val, new_nan_val in fields:
         data[f] = raw_data[f.upper()].reshape(n_records, 3)
         valid = raw_unscaled[f.upper()].reshape(n_records, 3) != nan_val
-        data[f][~valid] = nan_val
+        data[f][~valid] = new_nan_val
 
     fields = ["sat_track_azi", "abs_line_number"]
     for f in fields:

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -148,7 +148,9 @@ class AscatL1bEpsSzfFile(AscatFile):
             for d in data:
                 merged_data[beam].append(d.pop(beam))
             if isinstance(merged_data[beam][0], xr.Dataset):
-                merged_data[beam] = xr.concat(merged_data[beam], dim="obs")
+                merged_data[beam] = xr.concat(merged_data[beam],
+                                              dim="obs",
+                                              combine_attrs="drop_conflicts")
             else:
                 merged_data[beam] = np.hstack(merged_data[beam])
 
@@ -213,12 +215,14 @@ class AscatL1bEpsFile(AscatFile):
                     for d in data:
                         merged_data[beam].append(d.pop(beam))
                     if isinstance(merged_data[beam][0], xr.Dataset):
-                        merged_data[beam] = xr.concat(merged_data[beam], dim="obs")
+                        merged_data[beam] = xr.concat(merged_data[beam],
+                                                      dim="obs",
+                                                      combine_attrs="drop_conflicts")
                     else:
                         merged_data[beam] = np.hstack(merged_data[beam])
             else:
                 if isinstance(merged_data[beam][0], xr.Dataset):
-                    merged_data = xr.concat(data, dim="obs")
+                    merged_data = xr.concat(data, dim="obs", combine_attrs="drop_conflicts")
                 else:
                     merged_data = np.hstack(data)
 
@@ -284,7 +288,7 @@ class AscatL2EpsFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                data = xr.concat(data, dim="obs")
+                data = xr.concat(data, dim="obs", combine_attrs="drop_conflicts")
             else:
                 data = np.hstack(data)
             data = (data, metadata)

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -45,20 +45,20 @@ from ascat.utils import get_toi_subset, get_roi_subset
 from ascat.utils import get_bit, set_bit
 from ascat.utils import dtype_to_nan
 from ascat.utils import mask_dtype_nans
+from ascat.utils import int8_nan, uint8_nan
+from ascat.utils import int16_nan, uint16_nan
+from ascat.utils import int32_nan, uint32_nan
+from ascat.utils import float32_nan
 from ascat.read_native import AscatFile
 
 short_cds_time = np.dtype([("day", ">u2"), ("time", ">u4")])
 long_cds_time = np.dtype([("day", ">u2"), ("ms", ">u4"), ("mms", ">u2")])
 
-long_nan = np.iinfo(np.int32).min
-ulong_nan = np.iinfo(np.uint32).max
-int_nan = np.iinfo(np.int16).min
-uint_nan = np.iinfo(np.uint16).max
-int8_nan = np.iinfo(np.int8).min
-uint8_nan = np.iinfo(np.uint8).max
-int32_nan = np.iinfo(np.int32).min
-uint32_nan = np.iinfo(np.uint32).max
-float32_nan = -999999.
+
+long_nan = int32_nan
+ulong_nan = uint32_nan
+int_nan = int16_nan
+uint_nan = uint16_nan
 
 # 2000-01-01 00:00:00
 julian_epoch = 2451544.5

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -44,7 +44,6 @@ from datetime import timedelta
 from ascat.utils import get_toi_subset, get_roi_subset
 from ascat.utils import get_bit, set_bit
 from ascat.utils import dtype_to_nan
-from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 
 short_cds_time = np.dtype([("day", ">u2"), ("time", ">u4")])
@@ -1119,7 +1118,6 @@ def read_eps_l1b(filename,
                     coords[cf] = sub_data.pop(cf)
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords, attrs=metadata)
-                ds[beam] = mask_dtype_nans(ds[beam])
             else:
                 # collect dtype info
                 dtype = []
@@ -1191,7 +1189,6 @@ def read_eps_l1b(filename,
                 coords[cf] = data.pop(cf)
 
             ds = xr.Dataset(data, coords=coords, attrs=metadata)
-            ds = mask_dtype_nans(ds)
         else:
             # collect dtype info
             dtype = []
@@ -1280,7 +1277,6 @@ def read_eps_l2(filename, generic=False, to_xarray=False, return_ptype=False):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
-            data = mask_dtype_nans(data)
 
         else:
             # collect dtype info

--- a/src/ascat/read_native/eps_native.py
+++ b/src/ascat/read_native/eps_native.py
@@ -44,6 +44,7 @@ from datetime import timedelta
 from ascat.utils import get_toi_subset, get_roi_subset
 from ascat.utils import get_bit, set_bit
 from ascat.utils import dtype_to_nan
+from ascat.utils import mask_dtype_nans
 
 short_cds_time = np.dtype([("day", ">u2"), ("time", ">u4")])
 long_cds_time = np.dtype([("day", ">u2"), ("ms", ">u4"), ("mms", ">u2")])
@@ -1167,6 +1168,7 @@ def read_eps_l1b(filename,
                     coords[cf] = sub_data.pop(cf)
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords, attrs=metadata)
+                ds[beam] = mask_dtype_nans(ds[beam])
             else:
                 # collect dtype info
                 dtype = []
@@ -1238,6 +1240,7 @@ def read_eps_l1b(filename,
                 coords[cf] = data.pop(cf)
 
             ds = xr.Dataset(data, coords=coords, attrs=metadata)
+            ds = mask_dtype_nans(ds)
         else:
             # collect dtype info
             dtype = []
@@ -1326,6 +1329,8 @@ def read_eps_l2(filename, generic=False, to_xarray=False, return_ptype=False):
                 coords[cf] = data.pop(cf)
 
             data = xr.Dataset(data, coords=coords, attrs=metadata)
+            data = mask_dtype_nans(data)
+
         else:
             # collect dtype info
             dtype = []

--- a/src/ascat/read_native/hdf5.py
+++ b/src/ascat/read_native/hdf5.py
@@ -37,12 +37,11 @@ import h5py
 import numpy as np
 import xarray as xr
 
+from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 from ascat.read_native.eps_native import set_flags
 
-
 class AscatL1bHdf5File(AscatFile):
-
     """
     Class reading ASCAT Level 1b file in HDF5 format.
     """
@@ -168,6 +167,8 @@ class AscatL1bHdf5File(AscatFile):
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords,
                                       attrs=metadata)
+                if generic:
+                    data = mask_dtype_nans(data)
             else:
                 # collect dtype info
                 dtype = []
@@ -227,6 +228,13 @@ class AscatL1bHdf5File(AscatFile):
         merged_data = (merged_data, metadata)
 
         return merged_data
+
+class AscatL1bHdf5FileGeneric(AscatL1bHdf5File):
+    """
+    The same as AscatL1bHdf5File but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 
 def conv_hdf5l1b_generic(data, metadata):

--- a/src/ascat/read_native/hdf5.py
+++ b/src/ascat/read_native/hdf5.py
@@ -36,6 +36,7 @@ import h5py
 import numpy as np
 import xarray as xr
 
+from ascat.utils import mask_dtype_nans
 from ascat.read_native.eps_native import set_flags
 
 
@@ -176,6 +177,7 @@ class AscatL1bHdf5File:
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords,
                                       attrs=metadata)
+                ds[beam] = mask_dtype_nans(ds[beam])
             else:
                 # collect dtype info
                 dtype = []

--- a/src/ascat/read_native/hdf5.py
+++ b/src/ascat/read_native/hdf5.py
@@ -37,7 +37,6 @@ import h5py
 import numpy as np
 import xarray as xr
 
-from ascat.utils import mask_dtype_nans
 from ascat.read_native import AscatFile
 from ascat.read_native.eps_native import set_flags
 
@@ -169,7 +168,6 @@ class AscatL1bHdf5File(AscatFile):
 
                 ds[beam] = xr.Dataset(sub_data, coords=coords,
                                       attrs=metadata)
-                ds[beam] = mask_dtype_nans(ds[beam])
             else:
                 # collect dtype info
                 dtype = []

--- a/src/ascat/read_native/hdf5.py
+++ b/src/ascat/read_native/hdf5.py
@@ -30,6 +30,7 @@
 Readers for ASCAT Level 1b in HDF5 format.
 """
 
+from collections import defaultdict
 from collections import OrderedDict
 
 import h5py
@@ -37,29 +38,19 @@ import numpy as np
 import xarray as xr
 
 from ascat.utils import mask_dtype_nans
+from ascat.read_native import AscatFile
 from ascat.read_native.eps_native import set_flags
 
 
-class AscatL1bHdf5File:
+class AscatL1bHdf5File(AscatFile):
 
     """
     Class reading ASCAT Level 1b file in HDF5 format.
     """
 
-    def __init__(self, filename):
+    def _read(self, filename, generic=False, to_xarray=False):
         """
-        Initialize AscatL1bHdf5File.
-
-        Parameters
-        ----------
-        filename : str
-            Filename.
-        """
-        self.filename = filename
-
-    def read(self, generic=False, to_xarray=False):
-        """
-        Read ASCAT Level 1b data.
+        Read one ASCAT Level 1b HDF5 file.
 
         Parameters
         ----------
@@ -85,7 +76,7 @@ class AscatL1bHdf5File:
         mdr_descr_path = root + "DATA/MDR_1B_FULL_ASCA_Level_1_DESCR"
         metadata_path = root + "METADATA"
 
-        with h5py.File(self.filename, mode="r") as fid:
+        with h5py.File(filename, mode="r") as fid:
             mdr = fid[mdr_path]
             mdr_descr = fid[mdr_descr_path]
             mdr_metadata = fid[metadata_path]
@@ -144,6 +135,7 @@ class AscatL1bHdf5File:
         # 4 Right Fore Antenna, 5 Right Mid Antenna, 6 Right Aft Antenna
         left_beams = ["lf-vv", "lm-vv", "la-vv"]
         right_beams = ["rf-vv", "rm-vv", "ra-vv"]
+
         all_beams = left_beams + right_beams
 
         ds = OrderedDict()
@@ -201,11 +193,40 @@ class AscatL1bHdf5File:
 
         return ds, metadata
 
-    def close(self):
+    def _merge(self, data):
         """
-        Close file.
+        Merge data.
+
+        Parameters
+        ----------
+        data : list
+            List of array.
+
+        Returns
+        -------
+        data : numpy.ndarray
+            Data.
         """
-        pass
+        left_beams = ["lf-vv", "lm-vv", "la-vv"]
+        right_beams = ["rf-vv", "rm-vv", "ra-vv"]
+        all_beams = left_beams + right_beams
+
+        metadata = {}
+
+        if isinstance(data[0], tuple):
+            data, metadata = zip(*data)
+        merged_data = defaultdict(list)
+        for beam in all_beams:
+            for d in data:
+                merged_data[beam].append(d.pop(beam))
+            if isinstance(merged_data[beam][0], xr.Dataset):
+                merged_data[beam] = xr.concat(merged_data[beam], dim="obs")
+            else:
+                merged_data[beam] = np.hstack(merged_data[beam])
+
+        merged_data = (merged_data, metadata)
+
+        return merged_data
 
 
 def conv_hdf5l1b_generic(data, metadata):

--- a/src/ascat/read_native/hdf5.py
+++ b/src/ascat/read_native/hdf5.py
@@ -218,7 +218,9 @@ class AscatL1bHdf5File(AscatFile):
             for d in data:
                 merged_data[beam].append(d.pop(beam))
             if isinstance(merged_data[beam][0], xr.Dataset):
-                merged_data[beam] = xr.concat(merged_data[beam], dim="obs")
+                merged_data[beam] = xr.concat(merged_data[beam],
+                                              dim="obs",
+                                              combine_attrs="drop_conflicts")
             else:
                 merged_data[beam] = np.hstack(merged_data[beam])
 

--- a/src/ascat/read_native/nc.py
+++ b/src/ascat/read_native/nc.py
@@ -250,7 +250,9 @@ class AscatL1bNcFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                data = xr.concat(data, dim="obs")
+                data = xr.concat(data,
+                                 dim="obs",
+                                 combine_attrs="drop_conflicts")
             else:
                 data = np.hstack(data)
             data = (data, metadata)
@@ -348,7 +350,9 @@ class AscatL2NcFile(AscatFile):
         if isinstance(data[0], tuple):
             data, metadata = zip(*data)
             if isinstance(data[0], xr.Dataset):
-                data = xr.concat(data, dim="obs")
+                data = xr.concat(data,
+                                 dim="obs",
+                                 combine_attrs="drop_conflicts")
             else:
                 data = np.hstack(data)
             data = (data, metadata)
@@ -602,7 +606,9 @@ class AscatSsmNcSwathFileList(ChronFiles):
                 print(f"Error reading: {self.fid.filename}")
 
         if merged_data:
-            merged_data = xr.concat(merged_data, dim="obs")
+            merged_data = xr.concat(merged_data,
+                                    dim="obs",
+                                    combine_attrs="drop_conflicts")
         else:
             merged_data = None
 

--- a/src/ascat/read_native/nc.py
+++ b/src/ascat/read_native/nc.py
@@ -39,11 +39,10 @@ import xarray as xr
 from ascat.utils import tmp_unzip
 from ascat.utils import daterange
 from ascat.utils import mask_dtype_nans
+from ascat.utils import uint8_nan
+from ascat.utils import float32_nan
 from ascat.file_handling import ChronFiles
 from ascat.read_native import AscatFile
-
-float32_nan = -999999.
-uint8_nan = np.iinfo(np.uint8).max
 
 
 def read_nc(filename, generic, to_xarray, skip_fields, gen_fields_lut):

--- a/src/ascat/read_native/nc.py
+++ b/src/ascat/read_native/nc.py
@@ -38,7 +38,6 @@ import xarray as xr
 
 from ascat.utils import tmp_unzip
 from ascat.utils import daterange
-from ascat.utils import mask_dtype_nans
 from ascat.file_handling import ChronFiles
 from ascat.read_native import AscatFile
 
@@ -166,7 +165,6 @@ def read_nc(filename, generic, to_xarray, skip_fields, gen_fields_lut):
             coords[cf] = data.pop(cf)
 
         data = xr.Dataset(data, coords=coords, attrs=metadata)
-        data = mask_dtype_nans(data)
     else:
         ds = np.empty(num_records, dtype=np.dtype(dtype))
         for k, v in data.items():

--- a/src/ascat/read_native/nc.py
+++ b/src/ascat/read_native/nc.py
@@ -38,6 +38,7 @@ import xarray as xr
 
 from ascat.utils import tmp_unzip
 from ascat.utils import daterange
+from ascat.utils import mask_dtype_nans
 from ascat.file_handling import ChronFiles
 from ascat.read_native import AscatFile
 
@@ -165,6 +166,8 @@ def read_nc(filename, generic, to_xarray, skip_fields, gen_fields_lut):
             coords[cf] = data.pop(cf)
 
         data = xr.Dataset(data, coords=coords, attrs=metadata)
+        if generic:
+            data = mask_dtype_nans(data)
     else:
         ds = np.empty(num_records, dtype=np.dtype(dtype))
         for k, v in data.items():
@@ -260,6 +263,13 @@ class AscatL1bNcFile(AscatFile):
             data = np.hstack(data)
 
         return data
+
+class AscatL1bNcFileGeneric(AscatL1bNcFile):
+    """
+    The same as AscatL1bNcFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 
 class AscatL2NcFile(AscatFile):
@@ -360,6 +370,13 @@ class AscatL2NcFile(AscatFile):
             data = np.hstack(data)
 
         return data
+
+class AscatL2NcFileGeneric(AscatL2NcFile):
+    """
+    The same as AscatL1bNcFile but with generic=True by default.
+    """
+    def _read(self, filename, generic=True, to_xarray=False, **kwargs):
+        return super()._read(filename, generic=generic, to_xarray=to_xarray, **kwargs)
 
 
 class AscatSsmNcSwathFile(AscatFile):

--- a/src/ascat/read_native/nc.py
+++ b/src/ascat/read_native/nc.py
@@ -38,6 +38,7 @@ import xarray as xr
 
 from ascat.utils import tmp_unzip
 from ascat.utils import daterange
+from ascat.utils import mask_dtype_nans
 from ascat.file_handling import ChronFiles
 
 float32_nan = -999999.
@@ -164,6 +165,7 @@ def read_nc(filename, generic, to_xarray, skip_fields, gen_fields_lut):
             coords[cf] = data.pop(cf)
 
         data = xr.Dataset(data, coords=coords, attrs=metadata)
+        data = mask_dtype_nans(data)
     else:
         ds = np.empty(num_records, dtype=np.dtype(dtype))
         for k, v in data.items():

--- a/src/ascat/utils.py
+++ b/src/ascat/utils.py
@@ -25,6 +25,8 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+
 from datetime import timedelta
 from gzip import GzipFile
 from tempfile import NamedTemporaryFile
@@ -381,6 +383,26 @@ def get_roi_subset(ds, roi):
 
     return ds
 
+def get_file_format(filename):
+    """
+    Try to guess the file format from the extension.
+
+    Parameters
+    ----------
+    filename : str
+        File name.
+
+    Returns
+    -------
+    file_format : str
+        File format indicator.
+    """
+    if os.path.splitext(filename)[1] == ".gz":
+        file_format = os.path.splitext(os.path.splitext(filename)[0])[1]
+    else:
+        file_format = os.path.splitext(filename)[1]
+
+    return file_format
 
 class Spacecraft:
     """

--- a/src/ascat/utils.py
+++ b/src/ascat/utils.py
@@ -58,6 +58,16 @@ dtype_to_nan = {
     np.dtype('O'): None,
 }
 
+def mask_dtype_nans(ds):
+    """
+    Mask NaNs in a dataset based on the dtypes of its variables.
+    """
+    for var in ds.data_vars:
+        if ds[var].dtype in dtype_to_nan and ~ds[var].isnull().any():
+            ds[var] = ds[var].where(ds[var] != dtype_to_nan[ds[var].dtype])
+    return ds
+
+
 def get_bit(a, bit_pos):
     """
     Returns 1 or 0 if bit is set or not.

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -40,7 +40,7 @@ import numpy as np
 from ascat.file_handling import FilenameTemplate
 from ascat.file_handling import FileSearch
 from ascat.file_handling import ChronFiles
-from ascat.file_handling import Csv
+from ascat.file_handling import CsvFile
 from ascat.file_handling import CsvFiles
 
 
@@ -57,7 +57,7 @@ def generate_test_data():
 
             filename = tmpdir / "temperature" / tile / f"202201{num}_ascat.csv"
 
-            csv_file = Csv(filename, mode="w")
+            csv_file = CsvFile(filename, mode="w")
             file_dates = [
                 datetime.strptime(f"202201{num}", "%Y%m%d") +
                 timedelta(seconds=(3600 * i + seconds))
@@ -99,7 +99,7 @@ def generate_test_data():
                     "%H%M%S"), file_dates[-2].strftime("%H%M%S")
                 filename = folder / Path(f"ascat_{d1}_{t1}-{d2}_{t2}.csv")
 
-                csv_file = Csv(filename, mode="w")
+                csv_file = CsvFile(filename, mode="w")
                 file_precips = random.choices(
                     range(0, 5), k=len(file_dates) - 1)
                 dtype = np.dtype([("date", "datetime64[s]"),
@@ -435,7 +435,7 @@ class TestChronFiles(CustomTestCase):
         """
         Setup test.
         """
-        cls = Csv
+        cls = CsvFile
         fn_templ = "{date}_ascat.csv"
         sf_templ = {"variables": "{variable}", "tiles": "{tile}"}
         cls_kwargs = None

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -143,6 +143,13 @@ class Test_AscatL2NcFile(unittest.TestCase):
         nptest.assert_allclose(
             data['mean_soil_moisture'][:25], ssm_mean_should, atol=1e-5)
 
+        data, metadata = self.reader.read(generic=True)
+        nptest.assert_allclose(data['lat'][:25], lats_should, atol=1e-5)
+        nptest.assert_allclose(
+            data['sm'][:25], ssm_should, atol=1e-5)
+        nptest.assert_allclose(
+            data['sm_mean'][:25], ssm_mean_should, atol=1e-5)
+
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="Does not work on Windows")
 class Test_AscatL2NcFile_AscatL2BufrFile(unittest.TestCase):


### PR DESCRIPTION
This PR adds a base class `ascat.file_handling.Filenames` which handles operations on filenames that are passed to it. It assumes child classes implement the needed methods out of: `_read` (for reading a single file), `_write` (for writing data to a single file), and `_merge` (for merging a list of data objects into a single one). It then handles the reading, writing, and merging of >=1 files using the subclass methods.

The PR also converts all the level 1 and 2 readers to Filenames subclasses along these lines. In fact, they are subclasses of a more general `ascat.read_native.AscatFile` subclass, which overrides the `Filenames` read method with some extra logic for spatio-temporal subsetting.

Some things I'm not sure on yet -
- Should subsetting be done on each file individually before merging or on the entire merged dataset after its read? I feel that the former makes more sense in terms of memory overhead but perhaps incurs unreasonable computational cost.

- I had to add a `read_generic` init argument to the `AscatFile` class, which determines the default value for `generic` in the `read` method of an `AscatFile` object if `read` is not passed a value for `generic` when called. This is to reproduce the behavior of the old `AscatL1bFile` and `AscatL2File` classes, which instantiated reader classes and always used their `read` methods with `generic=True` by default, whereas the reader classes _themselves_ had a default of `generic=False`. Perhaps there is a better solution though?

