### PR TITLE
Refactor temporal aggregator

### DIFF
--- a/src/ascat/aggregate/aggregators.py
+++ b/src/ascat/aggregate/aggregators.py
@@ -285,7 +285,7 @@ class TemporalSwathAggregator:
             grouped_ds = xarray_reduce(
                 ds[present_agg_vars],
                 ds["location_id"],
-                expected_groups=(expected_location_ids),
+                expected_groups=(expected_location_ids,),
                 func=self.agg)
 
             # convert the location_id back to an integer


### PR DESCRIPTION
Operates timestep by timestep rather than merging all source swaths into a dataset and writing out with a groupby.